### PR TITLE
refactor: auth 영역 리팩토링 및 api 추가

### DIFF
--- a/src/auth/_dto/login.dto.ts
+++ b/src/auth/_dto/login.dto.ts
@@ -1,0 +1,29 @@
+import { ApiProperty } from "@nestjs/swagger";
+import { IsEmail, IsNotEmpty, IsString } from "class-validator";
+
+export class LoginDTO {
+  @IsString()
+  @IsNotEmpty()
+  @IsEmail()
+  @ApiProperty({
+    name: "email",
+    type: String,
+    required: true,
+    nullable: false,
+    description: "이메일을 입력합니다.",
+    example: "abc@def.com",
+  })
+  email: string;
+
+  @IsString()
+  @IsNotEmpty()
+  @ApiProperty({
+    name: "password",
+    type: String,
+    required: true,
+    nullable: false,
+    description: "비밀번호를 입력합니다.",
+    example: "비밀번호486",
+  })
+  password: string;
+}

--- a/src/auth/_dto/response-login-dto.ts
+++ b/src/auth/_dto/response-login-dto.ts
@@ -1,0 +1,26 @@
+import { ApiProperty } from "@nestjs/swagger";
+
+export class ResponseInfoItemDTO {
+  @ApiProperty({ description: "유저 고유 값", example: 1 })
+  id: number;
+
+  @ApiProperty({
+    description: "유저 uuid",
+    example: "andafs-asdfdsf-asdfsdf-asdfsadf",
+  })
+  userUuid: string;
+
+  @ApiProperty({ description: "유저 이름", example: "홍길동" })
+  name: string;
+
+  @ApiProperty({ description: "유저 이메일", example: "andg@sadf.com" })
+  email: string;
+}
+
+export class ResponseLoginDTO {
+  @ApiProperty({ description: "리턴 메시지", example: "success" })
+  message: string;
+
+  @ApiProperty({ description: "유저정보", type: ResponseInfoItemDTO })
+  user: ResponseInfoItemDTO;
+}

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -2,24 +2,73 @@ import {
   Body,
   Controller,
   Get,
+  HttpStatus,
   NotFoundException,
   Post,
   Req,
   Res,
+  UnauthorizedException,
   UseGuards,
 } from "@nestjs/common";
 import { AuthService } from "./auth.service";
 import { Request, Response } from "express";
 import { JwtAuthGuard } from "./security/auth.guard";
+import {
+  ApiBearerAuth,
+  ApiBody,
+  ApiOkResponse,
+  ApiOperation,
+  ApiTags,
+  ApiUnprocessableEntityResponse,
+} from "@nestjs/swagger";
+import { LoginDTO } from "./_dto/login.dto";
+import { ResponseLoginDTO } from "./_dto/response-login-dto";
+import { ResponseCommonSuccessDTO } from "src/_common/_dto/common-success-response.dto";
 
 @Controller("auth")
+@ApiTags("auth")
 export class AuthController {
   constructor(private authService: AuthService) {}
 
   @Post("login")
+  @ApiOperation({
+    summary: "회원 로그인",
+    description: `
+      회원이 로그인을 합니다.
+      - accessToken은 request headers의 Authorization에 Bearer 형태로 값이 존재합니다.
+      - refreshToken은 application의 cookies에 refreshToken으로 값이 존재합니다.
+      - accessToken의 유효시간은 생성후 "15분", refreshToken은 생성후 "7일"입니다. 
+    `,
+  })
+  @ApiBody({
+    description: "로그인에 사용되는 정보 입니다.",
+    required: true,
+    type: LoginDTO,
+  })
+  @ApiUnprocessableEntityResponse({
+    description: "잘못된 비밀번호 입력시",
+    example: {
+      message: "not matched password",
+      error: "Unprocessable Entity",
+      statusCode: HttpStatus.UNPROCESSABLE_ENTITY,
+    },
+  })
+  @ApiOkResponse({
+    description: "로그인 성공",
+    example: {
+      message: "success",
+      accessToken:
+        "eyJhbGiIsInR5cCI6IkpXVCJ9.eyJpZCI6NCwidXNlclV1aWQiOiJkOTE0MzNmNC0zMDdkLTRmZjUtODQ3Ni0wNzU0OTI5OTc1NzciLCJuYW1lIjoi7J207ZmN7Je0IiWxlcjEwMDRAbmF2ZXIuY29tIiwiaWF0IjoxNzUyMTU4MjQzLCJleHAiOjE3NTIyNDQ2NDN9.Fcy7QIh_Y-wK0jGeSgbon4hg8S",
+      info: {
+        id: 0,
+        userUuid: "d91433f4-307d-4ff5-8476-23458324759834",
+        name: "홍길동",
+        email: "hong@bape.in",
+      },
+    },
+  })
   async login(
-    @Body("email") email: string,
-    @Body("password") password: string,
+    @Body() loginDto: LoginDTO,
     @Res({ passthrough: true }) res: Response,
     /**
      * passthrogh 사용하는 이유
@@ -29,20 +78,87 @@ export class AuthController {
      * 그러나 경우에 따라서는 미들웨어에서 이미 조작된 응답 객체를 라우터 핸들러로 전달하고 싶을 때, @Res({ passthrough: true })를 사용합니다.
      * 이렇게 하면 해당 응답 객체가 라우터 핸들러로 전달되기 전에 미들웨어에서 조작된 내용이 유지됩니다.
      */
-  ) {
-    const accessToken = await this.authService.login(email, password);
+  ): Promise<ResponseLoginDTO> {
+    const loginInfo = await this.authService.login(loginDto);
     res.header("Access-Control-Expose-Headers", "Authorization");
-    res.setHeader("Authorization", "Bearer " + accessToken.accessToken);
-    res.cookie("accessToken", accessToken.accessToken);
+    res.setHeader("Authorization", "Bearer " + loginInfo.accessToken);
+    // res.cookie("accessToken", loginInfo.accessToken);
+    /**
+     * accessToken은 setHeader에 심어서 프론트에서 꺼내서 사용할 수 있도록 하는걸 추천
+     * 프론트에서 명확히 제어가능, CORS, 보안정책 대응 용이
+     */
+    res.cookie("refreshToken", loginInfo.refreshToken, {
+      httpOnly: true,
+      secure: true,
+      sameSite: "strict",
+      maxAge: 1000 * 60 * 60 * 24 * 7, // 7d
+    });
 
     return {
       message: "success",
-      token: accessToken.accessToken,
-      info: accessToken.payload,
+      // accessToken: loginInfo.accessToken,
+      /**
+       * accessToken을 response에 굳이 노출하지 않고 프론트에서 headers의 Authorization에 전달
+       * 하는것으로 내용은 충분하기때문에 리턴값에 노출시키지 않는다.
+       */
+      // refreshToken: loginInfo.refreshToken,
+      /**
+       * 가능하면 refreshToken은 프론트에 직접 전달하지 않는 것이 보안상 좋습니다.
+       * 이유: XSS 공격에 취약 → 공격자가 토큰 탈취 후 무한 재발급 가능.
+       */
+      user: loginInfo.payload,
     };
   }
 
+  @Post("refresh")
+  @ApiOperation({
+    summary: "accessToken 재발급",
+    description:
+      "accessToken이 만료되었을때 refreshToken을 통해서 accessToken을  재발급을 합니다.",
+  })
+  async refresh(
+    @Req() req: Request,
+    @Res({ passthrough: true }) res: Response,
+  ): Promise<void> {
+    const refreshToken = req.cookies.refreshToken;
+
+    if (!refreshToken) {
+      throw new UnauthorizedException("Refresh token not found");
+    }
+
+    const { accessToken, refreshToken: newRefreshToken } =
+      await this.authService.refreshAccessToken(refreshToken);
+
+    res.setHeader("Authorization", "Bearer " + accessToken);
+    res.cookie("refreshToken", newRefreshToken, {
+      httpOnly: true,
+      secure: true,
+      sameSite: "strict",
+      maxAge: 1000 * 60 * 60 * 24 * 7,
+    });
+    return;
+  }
+
+  @Get("me")
+  @ApiOperation({
+    summary: "내 정보 가져오기",
+    description:
+      "토큰에 대한 유효기간을 확인하기 위해 사용자의 정보를 가져옵니다.",
+  })
+  @ApiBearerAuth("accessToken")
+  @UseGuards(JwtAuthGuard)
+  getMe(@Req() req: Request) {
+    return req.user;
+  }
+
   @Get("authentication")
+  @ApiOperation({
+    summary: "로그인후에 유저정보 체크용",
+    description:
+      "로그인 / refreshToken 기능추가로 인해 me api 추가 되어 해당 api는 현재 사용하지 않습니다.",
+    deprecated: true,
+    tags: ["미사용"],
+  })
   @UseGuards(JwtAuthGuard)
   async isAuthenticate(@Req() req: Request) {
     const token = req.cookies["accessToken"];
@@ -57,22 +173,46 @@ export class AuthController {
     };
   }
 
+  @ApiOperation({
+    summary: "로그아웃",
+    description: `
+      회원이 로그아웃 합니다.
+        - Headers의 Authorization 헤더 제거는 클라이언트가 제거해야 합니다.
+        - 서버에서는 쿠키의 refreshToken만 제거합니다.
+      `,
+  })
+  @ApiOkResponse({
+    description: "로그아웃 성공",
+    type: ResponseCommonSuccessDTO,
+    example: {
+      message: "logout",
+      statusCode: HttpStatus.OK,
+    },
+  })
   @Post("logout")
-  async logout(@Res() res: Response) {
+  logout(@Res({ passthrough: true }) res: Response): ResponseCommonSuccessDTO {
+    /**
+     * accessToken은 headers의 Authorization에 있어 프론트에서 헤더를 제거
+     *  -> req.headers.Authorization은 클라이언트가 요청할 때 넣은 값
+     *  -> 서버는 그 값을 읽기만 가능하고 클라이언트 저장소(브라우저, 앱의 localStorage/cookie 등)를 직접 조작할 수 없다.
+     * refreshToken은 cookie로 존재하기때문에 백엔드에서 핸들링 가능
+     */
+
     //case1. cookie 메소드에서 유효기간 0
-    // res.cookie('accessToken', '', {
+    // res.cookie('refreshToken', '', {
     //   maxAge: 0
     // })
 
     //case2. clearCookie 메소드 사용
-    res.clearCookie("accessToken");
+    res.clearCookie("refreshToken");
 
     //case3.setCookie에 토큰값 null string으로 사전처리(그럼 유저정보가 없기때문에 접근을 못하도록 사전처리됨)
     // res.setHeader('Authorization', '') //좀 더 강화하려면 setHeader도 null string처리 해주는것도 좋을것 같음.
-    // res.cookie('accessToken', '')
+    // res.cookie('refreshToken', '')
 
-    return res.send({
-      message: "success",
-    });
+    return {
+      message: "logout",
+      statusCode: HttpStatus.OK,
+    };
   }
 }

--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -11,7 +11,7 @@ import { JwtStrategy } from "./security/passport.jwt.strategy";
     UserModule,
     JwtModule.register({
       secret: `${process.env.JWT_SECRET_KEY}` || "jwtSecretKey",
-      signOptions: { expiresIn: "1d" },
+      signOptions: { expiresIn: "1d" }, //default값이지만 사용되는 jwt sign에서 expiresIn사용시 사용되는 메소드에서 override됨.
     }),
     PassportModule,
   ],

--- a/src/auth/security/auth.guard.ts
+++ b/src/auth/security/auth.guard.ts
@@ -4,9 +4,9 @@ import { Observable } from "rxjs";
 
 @Injectable()
 export class JwtAuthGuard extends AuthGuard("jwt") {
-  canActivate(
-    context: ExecutionContext,
-  ): boolean | Promise<boolean> | Observable<boolean> {
-    return super.canActivate(context);
-  }
+  // canActivate(
+  //   context: ExecutionContext,
+  // ): boolean | Promise<boolean> | Observable<boolean> {
+  //   return super.canActivate(context);
+  // }
 }

--- a/src/auth/security/passport.jwt.strategy.ts
+++ b/src/auth/security/passport.jwt.strategy.ts
@@ -22,8 +22,10 @@ const fromAuthCookie = function () {
 export class JwtStrategy extends PassportStrategy(Strategy) {
   constructor(private authService: AuthService) {
     super({
-      // headers.authorization으로 받도록 설정하는 부분은 주석처리
-      // jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
+      /**
+       * headers.authorization으로 받도록 설정
+       */
+      jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
       // // cookie로 jwt 토큰 받도록 설정
       // jwtFromRequest: ExtractJwt.fromExtractors([
       //   (request) => {
@@ -31,28 +33,42 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
       //   },
       // ]),
       // bearer cookie로
-      jwtFromRequest: fromAuthCookie(),
+      // jwtFromRequest: fromAuthCookie(),
       //ignoreExpiration => 특정 상황에서 만료 시간을 무시하고 토큰을 계속해서 검증하고 싶다면 ignoreExpiration을 true로 설정. 개발 환경에서 토큰 만료 시간을 무시하고 접근이 가능.
       //false이면, 만료된 토큰의 경우 인증이 실패됨.
-      ignoreExpiration: true,
-      algorithms: ["HS256"],
+      ignoreExpiration: false,
+      algorithms: ["HS256"], //옵션에 명시하지 않아도 기본값으로 사용됨.
       type: "jwt", //타입을 명시적으로 작성(이외의 타입 : 'local', 'jwt', 'bearer', 'basic' 등)
       secretOrKey: `${process.env.JWT_SECRET_KEY}` || "jwtSecretKey", //, => auth.Module에서 register()에 secret의 value값과 일치해야함.
     });
   }
 
-  async validate(payload: Payload, done: VerifiedCallback): Promise<any> {
-    const user = await this.authService.tokenValidateUser(payload);
-
-    if (!user.payload) {
-      return done(
-        new UnauthorizedException({
-          message: "user does not exist or undefined user Info",
-        }),
-        false,
-      );
-    }
-
-    return done(null, user.payload);
+  async validate(payload: Payload) {
+    return {
+      id: payload.id,
+      userUuid: payload.userUuid,
+      name: payload.name,
+      email: payload.email,
+    };
   }
+
+  /**
+   * 레거시 validate
+   * 레거시가 된 이유: 목적자체는 DB를 사용하지 않는것인데 tokenValidateUser에서 DB를 조회하기때문에
+   * 해당 부분을 효율적으로 사용하고자 하기 위하여 레거시가 되었고 위의 validate를 사용함.
+   */
+  // async validate(payload: Payload, done: VerifiedCallback): Promise<any> {
+  //   const user = await this.authService.tokenValidateUser(payload);
+
+  //   if (!user.payload) {
+  //     return done(
+  //       new UnauthorizedException({
+  //         message: "user does not exist or undefined user Info",
+  //       }),
+  //       false,
+  //     );
+  //   }
+
+  //   return done(null, user.payload);
+  // }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -22,6 +22,16 @@ async function bootstrap() {
     .setDescription("나홀로 nest")
     .setVersion("1.0.0")
     .addTag("nest prac")
+    .addBearerAuth(
+      {
+        type: "http",
+        scheme: "bearer",
+        bearerFormat: "JWT",
+        name: "Authorization",
+        in: "header",
+      },
+      "accessToken",
+    )
     .build();
 
   const documentFactory = () =>


### PR DESCRIPTION
- 스웨거
    - ui에 Authorize 추가
    - 각 auth의 api에 스웨거 문서화 추가
- Jwt
    - headers.authorization으로 받도록 설정
    - 만료기간 무시 true -> fase로 변경
    - Validate 방식 변경(DB 조회 없이 처리되도록 변경)
- refresh, me, logout api 추가
- 로그인에서 user 조회시 숏템플릿 -> 바인딩 방식으로 변경
- refreshToken 추가
- accessToken은 헤더스 Authorization으로 위치 변경
- DTO
    - loginDTO , ResponseLoginDTO 추가