### PR TITLE
add: 쿠폰 기능 추가(선착순 쿠폰 발급시 동시성 처리 반영)

### DIFF
--- a/entities/coupons/coupon-issued-log.entity.ts
+++ b/entities/coupons/coupon-issued-log.entity.ts
@@ -1,0 +1,51 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  PrimaryGeneratedColumn,
+} from "typeorm";
+
+@Entity("coupon_issued_log")
+export class CouponIssuedLogEntity {
+  @PrimaryGeneratedColumn("increment", {
+    name: "id",
+    type: "int",
+    unsigned: true,
+    comment: "쿠폰로그 고유 번호",
+  })
+  id: number;
+
+  @Column({
+    name: "userId",
+    type: "int",
+    nullable: false,
+    comment: "쿠폰 이용 사용자 정보",
+  })
+  userId: number;
+
+  @Column({
+    name: "couponId",
+    type: "int",
+    nullable: false,
+    comment: "쿠폰 고유 아이디",
+  })
+  couponId: number;
+
+  @Column({
+    name: "action",
+    type: "varchar",
+    length: 255,
+    nullable: false,
+    comment:
+      "쿠폰 형태 정보(issued: 발행, used: 사용, cancelled: 사용취소, soldout: 쿠폰매진, already: 이미 발행됨)",
+  })
+  action: string;
+
+  @CreateDateColumn({
+    name: "createdDt",
+    type: "datetime",
+    nullable: false,
+    comment: "쿠폰 로그 생성일시",
+  })
+  createdDt: Date;
+}

--- a/entities/coupons/coupon-issued.entity.ts
+++ b/entities/coupons/coupon-issued.entity.ts
@@ -1,0 +1,88 @@
+import { UserEntity } from "entities/user.entity";
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  Index,
+  JoinColumn,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+} from "typeorm";
+import { CouponEntity } from "./coupon.entity";
+import { Exclude } from "class-transformer";
+
+@Entity("coupon_issued")
+@Index(["userId", "couponId"], { unique: true }) // 쿠폰 발급시 필요한 인덱스 추가
+export class CouponIssuedEntity {
+  @PrimaryGeneratedColumn("increment", {
+    name: "id",
+    type: "int",
+    unsigned: true,
+    comment: "쿠폰 발행 고유 번호",
+  })
+  id: number;
+
+  @Column({
+    name: "userId",
+    type: "int",
+    unsigned: true,
+    nullable: false,
+    comment: "쿠폰 이용 사용자 정보",
+  })
+  userId: number;
+
+  @Column({
+    name: "couponId",
+    type: "int",
+    unsigned: true,
+    nullable: false,
+    comment: "쿠폰 고유 아이디",
+  })
+  couponId: number;
+
+  @Column({
+    name: "isUsed",
+    type: "tinyint",
+    default: false,
+    nullable: false,
+    comment: "쿠폰 사용 여부",
+  })
+  isUsed: boolean;
+
+  @Column({
+    name: "usedDt",
+    type: "datetime",
+    default: null,
+    nullable: true,
+    comment: "쿠폰 사용 일시",
+  })
+  usedDt: Date;
+
+  @CreateDateColumn({
+    name: "issuedDt",
+    type: "datetime",
+    nullable: false,
+    comment: "쿠폰 발급정보 생성일시",
+  })
+  issuedDt: Date;
+
+  @Column({
+    name: "expiredDt",
+    type: "datetime",
+    default: null,
+    nullable: true,
+    comment: "쿠폰 유효기간 일시",
+  })
+  expiredDt: Date;
+
+  //관계설정
+  @Exclude()
+  @ManyToOne(() => UserEntity, (user) => user.issuedCoupons)
+  @JoinColumn({ name: "userId" })
+  user: UserEntity;
+
+  @Exclude()
+  @ManyToOne(() => CouponEntity)
+  @JoinColumn({ name: "couponId" })
+  coupon: CouponEntity;
+}

--- a/entities/coupons/coupon.entity.ts
+++ b/entities/coupons/coupon.entity.ts
@@ -1,0 +1,202 @@
+import {
+  Column,
+  CreateDateColumn,
+  DeleteDateColumn,
+  Entity,
+  JoinColumn,
+  ManyToOne,
+  OneToMany,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn,
+} from "typeorm";
+import { CouponIssuedEntity } from "./coupon-issued.entity";
+import { Exclude } from "class-transformer";
+import { UserEntity } from "entities/user.entity";
+
+@Entity("coupon")
+export class CouponEntity {
+  @PrimaryGeneratedColumn("increment", {
+    name: "id",
+    type: "int",
+    unsigned: true,
+    comment: "쿠폰 고유 번호",
+  })
+  id: number;
+
+  @Column({
+    name: "code",
+    unique: true,
+    type: "varchar",
+    length: 255,
+    nullable: false,
+    comment: "쿠폰 코드",
+  })
+  code: string;
+
+  @Column({
+    name: "issuedUserId",
+    type: "int",
+    unsigned: true,
+    nullable: false,
+    comment: "쿠폰 생성 유저 고유값",
+  })
+  issuedUserId: number;
+
+  @Column({
+    name: "name",
+    type: "varchar",
+    length: 255,
+    nullable: false,
+    comment: "쿠폰 이름",
+  })
+  name: string;
+
+  @Column({
+    name: "description",
+    type: "text",
+    nullable: true,
+    comment: "쿠폰 부가설명",
+  })
+  description: string;
+
+  @Column({
+    name: "isActive",
+    type: "tinyint",
+    default: false,
+    nullable: false,
+    comment: "쿠폰 사용가능 여부",
+  })
+  isActive: boolean;
+
+  @Column({
+    /**
+     * discountType이 기획적으로 명확해지는 경우
+     * enum type으로 작업하는것이 더 명확해짐.
+     */
+    name: "discountType",
+    type: "varchar",
+    length: 255,
+    default: "NONE",
+    nullable: false,
+    comment: "쿠폰 할인 유형(PERCENT(%할인), AMOUNT(금액할인), NONE(할인없음))",
+  })
+  discountType: string;
+
+  @Column({
+    name: "discountValue",
+    type: "decimal",
+    precision: 10,
+    scale: 2,
+    nullable: true,
+    comment: "쿠폰 할인 값",
+  })
+  discountValue: string;
+
+  @Column({
+    name: "minPrice",
+    type: "decimal",
+    precision: 10,
+    scale: 2,
+    nullable: true,
+    comment: "최소 주문금액",
+  })
+  minPrice: string;
+
+  @Column({
+    name: "isIssuedLimited",
+    type: "tinyint",
+    default: false,
+    comment: "쿠폰 발행 개수 제한 여부",
+  })
+  isIssuedLimited: boolean;
+
+  @Column({
+    name: "totalCount",
+    type: "int",
+    default: null,
+    nullable: true,
+    comment: "발행 가능 총 개수(null = 무제한)",
+  })
+  totalCount: number;
+
+  @Column({
+    name: "issuedCount",
+    type: "int",
+    default: 0,
+    nullable: true,
+    comment: "발행된 수량",
+  })
+  issuedCount: number;
+
+  @Column({
+    name: "remainCount",
+    type: "int",
+    nullable: true,
+    comment: "발행제한 쿠폰시 쿠폰의 제한 잔여 개수",
+  })
+  remainCount: number;
+
+  @Column({
+    name: "isPeriodLimited",
+    type: "tinyint",
+    default: false,
+    nullable: false,
+    comment: "쿠폰 유효기간 여부",
+  })
+  isPeriodLimited: boolean;
+
+  @Column({
+    name: "startedDt",
+    type: "datetime",
+    default: null,
+    nullable: true,
+    comment: "쿠폰 유효기간 적용시 쿠폰 사용가능 시작일시",
+  })
+  startedDt: Date;
+
+  @Column({
+    name: "endedDt",
+    type: "datetime",
+    default: null,
+    nullable: true,
+    comment: "쿠폰 유효기간 적용시 쿠폰 사용종료 기한일시",
+  })
+  endedDt: Date;
+
+  @Exclude()
+  @CreateDateColumn({
+    name: "createdDt",
+    type: "datetime",
+    nullable: false,
+    comment: "쿠폰 정보 생성일시",
+  })
+  createdDt: Date;
+
+  @Exclude()
+  @UpdateDateColumn({
+    name: "updatedDt",
+    type: "datetime",
+    nullable: true,
+    comment: "쿠폰 정보 수정일시",
+  })
+  updatedDt: Date;
+
+  @Exclude()
+  @DeleteDateColumn({
+    name: "deletedDt",
+    type: "datetime",
+    nullable: true,
+    comment: "쿠폰 정보 삭제일시",
+  })
+  deletedDt: Date;
+
+  //관계 정보
+  @Exclude()
+  @OneToMany(() => CouponIssuedEntity, (couponIssued) => couponIssued.coupon)
+  issuedCoupons: CouponIssuedEntity[];
+
+  @Exclude()
+  @ManyToOne(() => UserEntity, (user) => user.coupons)
+  @JoinColumn({ name: "issuedUserId" })
+  user: UserEntity;
+}

--- a/entities/user.entity.ts
+++ b/entities/user.entity.ts
@@ -9,12 +9,15 @@ import {
 } from "typeorm";
 import { PostEntity } from "./post.entity";
 import { Exclude } from "class-transformer";
+import { CouponIssuedEntity } from "./coupons/coupon-issued.entity";
+import { CouponEntity } from "./coupons/coupon.entity";
 
 @Entity("user")
 export class UserEntity {
   @Exclude()
   @PrimaryGeneratedColumn("increment", {
     name: "id",
+    unsigned: true,
     comment: "유저 고유아이디",
   })
   id: number;
@@ -80,4 +83,12 @@ export class UserEntity {
   @Exclude()
   @OneToMany(() => PostEntity, (postEntity) => postEntity.user)
   posts: PostEntity[];
+
+  @Exclude()
+  @OneToMany(() => CouponIssuedEntity, (couponIssued) => couponIssued.user)
+  issuedCoupons: CouponIssuedEntity[];
+
+  @Exclude()
+  @OneToMany(() => CouponEntity, (coupon) => coupon.issuedUserId)
+  coupons: CouponEntity[];
 }

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -11,7 +11,11 @@ import { EmailModule } from "./mail/mail.module";
 import { ConfigModule } from "@nestjs/config";
 import { FileUploadModule } from "./file-upload/file-upload.module";
 import { RedisCacheModule } from "./redis/redis.module";
+import { CouponEntity } from "entities/coupons/coupon.entity";
+import { CouponIssuedEntity } from "entities/coupons/coupon-issued.entity";
+import { CouponIssuedLogEntity } from "entities/coupons/coupon-issued-log.entity";
 import { CommonModule } from "./_common/common.module";
+import { CouponModule } from "./coupon/coupon.module";
 
 @Module({
   imports: [
@@ -23,9 +27,15 @@ import { CommonModule } from "./_common/common.module";
       host: process.env.DB_HOST || "localhost",
       port: 3306,
       username: process.env.DB_USER_NAME || "root",
-      password: process.env.DB_PASSWORD || "ghdfuf2", //"root",
+      password: process.env.DB_PASSWORD || "ghdfuf2",
       database: "nest_prac",
-      entities: [UserEntity, PostEntity],
+      entities: [
+        UserEntity,
+        PostEntity,
+        CouponEntity,
+        CouponIssuedEntity,
+        CouponIssuedLogEntity,
+      ],
       synchronize: true,
       /**
        * timezone에서 "Asia/Seoul"의 값은 지원하지 않음
@@ -41,7 +51,7 @@ import { CommonModule } from "./_common/common.module";
        * => timezone 적용 안 됨
        */
       timezone: "Z",
-      logging: false, //개발환경에서 유용하게 활용함.
+      logging: true, //개발환경에서 유용하게 활용함.
       // logging: ['error', 'warn'] //운영 환경에서는 에러위주, 추가적으로 하면 경고까지도 하는 경우가 일반적인것 같음(chat GPT 내용 확인)
     }),
 
@@ -53,6 +63,7 @@ import { CommonModule } from "./_common/common.module";
     FileUploadModule,
     RedisCacheModule,
     CommonModule,
+    CouponModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/src/coupon/_dto/create-coupon-issue-by-user.dto.ts
+++ b/src/coupon/_dto/create-coupon-issue-by-user.dto.ts
@@ -1,0 +1,17 @@
+import { ApiProperty } from "@nestjs/swagger";
+import { IsNotEmpty, IsNumber } from "class-validator";
+
+export class CreateCouponIssueByUserDTO {
+  @IsNumber()
+  @IsNotEmpty()
+  @ApiProperty({
+    title: "유저에게 줄 쿠폰의 고유번호",
+    type: Number,
+    name: "couponId",
+    required: true,
+    nullable: false,
+    example: 1,
+    description: "유저에게 줄 쿠폰의 고유번호",
+  })
+  couponId: number;
+}

--- a/src/coupon/_dto/create-coupon.dto.ts
+++ b/src/coupon/_dto/create-coupon.dto.ts
@@ -1,0 +1,187 @@
+import { ApiProperty } from "@nestjs/swagger";
+import {
+  IsBoolean,
+  IsDateString,
+  IsNotEmpty,
+  IsNumber,
+  IsOptional,
+  IsString,
+  MinLength,
+} from "class-validator";
+
+export class CreateCouponDTO {
+  @IsString()
+  @IsOptional()
+  @MinLength(5)
+  @ApiProperty({
+    name: "code",
+    example: "WELCOME2025",
+    required: false,
+    nullable: true,
+    description: `
+      쿠폰 코드명(최소 5개의 문자+숫자 조합으로 만들어야합니다.)
+      * 클라이언트가 특정 쿠폰코드를 입력하지 않으면 7개 랜덤된 문자와 숫자 조합으로 쿠폰코드를 자동생성합니다.
+    `,
+  })
+  code?: string;
+
+  @IsString()
+  @IsNotEmpty()
+  @ApiProperty({
+    name: "name",
+    example: "10% 웰컴 할인 쿠폰",
+    required: true,
+    nullable: false,
+    description: "쿠폰 이름",
+  })
+  name: string;
+
+  @IsString()
+  @IsOptional()
+  @ApiProperty({
+    name: "description",
+    example: "해당 쿠폰은 처음 회원가입을 한 사람에게 발급하는 쿠폰입니다.",
+    required: false,
+    nullable: true,
+    description: "쿠폰의 설명입니다.",
+  })
+  description?: string;
+
+  @IsBoolean()
+  @IsOptional()
+  @ApiProperty({
+    name: "isActive",
+    example: true,
+    required: true,
+    nullable: false,
+    default: false,
+    description:
+      "쿠폰의 사용가능 여부 정보입니다. 기본값은 false(비활성) 입니다.",
+  })
+  isActive: boolean;
+
+  @IsString()
+  @IsNotEmpty()
+  @ApiProperty({
+    name: "discountType",
+    example: "PERCENT",
+    required: true,
+    nullable: false,
+    default: "NONE",
+    description: `
+      쿠폰의 할인 방법 입니다.
+      PERCENT(%할인), AMOUNT(금액 할인), NONE(할인 없음)으로 값을 구분합니다.
+    `,
+  })
+  discountType: string;
+
+  @IsString()
+  @IsNotEmpty()
+  @ApiProperty({
+    name: "discountValue",
+    example: "10",
+    required: false,
+    nullable: true,
+    default: null,
+    description: `
+      쿠폰의 할인 방법에 따른 할인 수 입니다.
+      퍼센트의 경우는 소수점이 없는 NumberStirng으로 들어가지만, 금액 할인인 경우에는 소수점 둘째자리까지 값이 등록됩니다.
+    `,
+  })
+  discountValue: string | null;
+
+  @IsString()
+  @IsOptional()
+  @ApiProperty({
+    name: "minPrice",
+    example: "1000.00",
+    required: false,
+    nullable: true,
+    default: null,
+    description: "할인 쿠폰 사용 최소 사용금액",
+  })
+  minPrice?: string;
+
+  @IsBoolean()
+  @IsNotEmpty()
+  @ApiProperty({
+    name: "isIssuedLimited",
+    example: true,
+    required: true,
+    nullable: false,
+    default: false,
+    description: "쿠폰 발행 개수 제한 여부",
+  })
+  isIssuedLimited: boolean;
+
+  @IsNumber()
+  @IsOptional()
+  @ApiProperty({
+    name: "totalCount",
+    example: null,
+    required: false,
+    nullable: true,
+    default: null,
+    description: "발행 가능 총 개수",
+  })
+  totalCount?: number;
+
+  // @IsNumber()
+  // @IsOptional()
+  // @ApiProperty({
+  //   name: "issuedCount",
+  //   example: 100,
+  //   required: false,
+  //   nullable: true,
+  //   default: 0,
+  //   description: "발행한 쿠폰 개수",
+  // })
+  // issuedCount?: number;
+
+  @IsNumber()
+  @IsOptional()
+  @ApiProperty({
+    name: "remainCount",
+    example: 10,
+    required: false,
+    nullable: true,
+    description: "잔여 쿠폰 개수",
+  })
+  remainCount?: number;
+
+  @IsBoolean()
+  @IsNotEmpty()
+  @ApiProperty({
+    name: "isPeriodLimited",
+    example: false,
+    required: true,
+    nullable: false,
+    default: false,
+    description: "쿠폰 기간 설정 여부",
+  })
+  isPeriodLimited: boolean;
+
+  @IsDateString()
+  @IsOptional()
+  @ApiProperty({
+    name: "startedDt",
+    example: "2025-08-05T00:00:00.000Z",
+    required: false,
+    nullable: true,
+    description:
+      "쿠폰 사용 시작일 (ISO 8601 형식, 예: 2025-08-05T00:00:00.000Z)",
+  })
+  startedDt?: Date;
+
+  @IsDateString()
+  @IsOptional()
+  @ApiProperty({
+    name: "endedDt",
+    example: "2025-08-31T23:59:59.000Z",
+    required: false,
+    nullable: true,
+    description:
+      "쿠폰 사용 종료일 (ISO 8601 형식, 예: 2025-08-31T23:59:59.000Z)",
+  })
+  endedDt?: Date;
+}

--- a/src/coupon/_dto/create-limit-coupon-issue-by-user.dto.ts
+++ b/src/coupon/_dto/create-limit-coupon-issue-by-user.dto.ts
@@ -1,0 +1,3 @@
+import { CreateCouponIssueByUserDTO } from "./create-coupon-issue-by-user.dto";
+
+export class CreateLimitCouponIssueByUserDTO extends CreateCouponIssueByUserDTO {}

--- a/src/coupon/_dto/reponse-success-get-my-coupon-list-dto.ts
+++ b/src/coupon/_dto/reponse-success-get-my-coupon-list-dto.ts
@@ -1,0 +1,54 @@
+import { ApiProperty } from "@nestjs/swagger";
+
+export class MyCouponItemDTO {
+  @ApiProperty({ example: 12 })
+  issuedId: number;
+
+  @ApiProperty({ example: false })
+  isUsed: boolean;
+
+  @ApiProperty({ example: "2025-08-01T00:00:00.000Z", nullable: true })
+  expiredDt: string | null;
+
+  // coupon fields (원하는 필드만 노출)
+  @ApiProperty({ example: 1 })
+  couponId: number;
+
+  @ApiProperty({ example: "WELCOME10" })
+  code: string;
+
+  @ApiProperty({ example: "10% 웰컴 쿠폰" })
+  name: string;
+
+  @ApiProperty({ example: "PERCENT" })
+  discountType: string;
+
+  @ApiProperty({ example: "10.00", nullable: true })
+  discountValue: string | null;
+
+  @ApiProperty({ example: "10000.00", nullable: true })
+  minPrice: string | null;
+
+  @ApiProperty({ example: true })
+  isActive: boolean;
+
+  @ApiProperty({ example: "2025-08-01T00:00:00.000Z", nullable: true })
+  startedDt: string | null;
+
+  @ApiProperty({ example: "2025-08-01T00:00:00.000Z", nullable: true })
+  endedDt: string | null;
+}
+
+export class ResponseSuccessGetMyCouponListDTO {
+  @ApiProperty({ type: [MyCouponItemDTO] })
+  coupons: MyCouponItemDTO[];
+
+  @ApiProperty({ example: 42 })
+  totalCount: number;
+
+  @ApiProperty({ example: 1 })
+  currPage: number;
+
+  @ApiProperty({ example: 5 })
+  totalPage: number;
+}

--- a/src/coupon/_dto/response-success-create-coupon.dto.ts
+++ b/src/coupon/_dto/response-success-create-coupon.dto.ts
@@ -1,0 +1,50 @@
+import { HttpStatus } from "@nestjs/common";
+import { ApiProperty } from "@nestjs/swagger";
+import { ResponseCommonSuccessDTO } from "src/_common/_dto/common-success-response.dto";
+
+export class ResponseCreateCouponDataDTO {
+  @ApiProperty({ example: 1 })
+  id: number;
+  @ApiProperty({ example: "WELCOME2025" })
+  code: string;
+  @ApiProperty({ example: 3 })
+  issuedUserId: number;
+  @ApiProperty({ example: "웰컴 10% 쿠폰" })
+  name: string;
+  @ApiProperty({ example: "회원가입시 제공하는 쿠폰입니다." })
+  description: string;
+  @ApiProperty({ example: false })
+  isActive: boolean;
+  @ApiProperty({ example: "NONE" })
+  discountType: string;
+  @ApiProperty({ example: "10" })
+  discountValue: string;
+  @ApiProperty({ example: "5000.00" })
+  minPrice: string;
+  @ApiProperty({ example: false })
+  isIssuedLimited: boolean;
+  @ApiProperty({ example: null })
+  totalCount: number;
+  @ApiProperty({ example: 0 })
+  issuedCount: number;
+  @ApiProperty({ example: 0 })
+  remainCount: number;
+  @ApiProperty({ example: false })
+  isPeriodLimited: boolean;
+  @ApiProperty({ example: "2025-08-05T00:00:00.000Z" })
+  startedDt: Date;
+  @ApiProperty({ example: "2025-08-31T23:59:59.000Z" })
+  endedDt: Date;
+}
+
+export class ResponseSuccessCreateCoupon extends ResponseCommonSuccessDTO {
+  @ApiProperty({ example: HttpStatus.CREATED })
+  statusCode: HttpStatus.CREATED;
+
+  @ApiProperty({
+    name: "data",
+    type: ResponseCreateCouponDataDTO,
+    description: "생성된 쿠폰 정보",
+  })
+  data: ResponseCreateCouponDataDTO;
+}

--- a/src/coupon/_dto/response-success-get-coupon-list.dto.ts
+++ b/src/coupon/_dto/response-success-get-coupon-list.dto.ts
@@ -1,0 +1,27 @@
+import { ApiProperty, OmitType } from "@nestjs/swagger";
+import { ResponseCreateCouponDataDTO } from "./response-success-create-coupon.dto";
+
+export class ResponseSuccessGetCouponListItemDTO extends OmitType(
+  ResponseCreateCouponDataDTO,
+  ["issuedUserId"],
+) {
+  @ApiProperty({ example: "2025-08-05T00:00:00.000Z" })
+  createdDt: Date;
+
+  @ApiProperty({ example: "2025-08-05T00:00:00.000Z" })
+  updatedDt: Date;
+}
+
+export class ResponseSuccessGetCouponListDTO {
+  @ApiProperty({ type: [ResponseSuccessGetCouponListItemDTO] })
+  data: ResponseSuccessGetCouponListItemDTO[];
+
+  @ApiProperty({ example: 100 })
+  totalCount: number;
+
+  @ApiProperty({ example: 1 })
+  currPage: number;
+
+  @ApiProperty({ example: 10 })
+  totalPage: number;
+}

--- a/src/coupon/_dto/response-success-get-coupon.dto.ts
+++ b/src/coupon/_dto/response-success-get-coupon.dto.ts
@@ -1,0 +1,54 @@
+import { ApiProperty } from "@nestjs/swagger";
+
+export class ResponseSuccessGetCouponDTO {
+  @ApiProperty({ example: 1 })
+  id: number;
+
+  @ApiProperty({ example: "WELCOME10" })
+  code: string;
+
+  @ApiProperty({ example: "10% 할인쿠폰" })
+  name: string;
+
+  @ApiProperty({ example: "회원가입 기념 10% 할인" })
+  description: string;
+
+  @ApiProperty({ example: true })
+  isActive: boolean;
+
+  @ApiProperty({ example: "PERCENT" })
+  discountType: string;
+
+  @ApiProperty({ example: "10" })
+  discountValue: string;
+
+  @ApiProperty({ example: "1000.00" })
+  minPrice: string;
+
+  @ApiProperty({ example: false })
+  isIssuedLimited: boolean;
+
+  @ApiProperty({ example: null })
+  totalCount: number;
+
+  @ApiProperty({ example: 0 })
+  issuedCount: number;
+
+  @ApiProperty({ example: 0 })
+  remainCount: number;
+
+  @ApiProperty({ example: false })
+  isPeriodLimited: boolean;
+
+  @ApiProperty({ example: "2025-08-01T00:00:00Z" })
+  startedDt: Date;
+
+  @ApiProperty({ example: "2025-08-31T23:59:59Z" })
+  endedDt: Date;
+
+  @ApiProperty({ example: "2025-08-01T00:00:00Z" })
+  createdDt: Date;
+
+  @ApiProperty({ example: "2025-08-01T00:00:00Z" })
+  updatedDt: Date;
+}

--- a/src/coupon/_dto/update-coupon.dto.ts
+++ b/src/coupon/_dto/update-coupon.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from "@nestjs/swagger";
+import { CreateCouponDTO } from "./create-coupon.dto";
+
+export class UpdateCouponDTO extends PartialType(CreateCouponDTO) {}

--- a/src/coupon/coupon-issued/coupon-issued.controller.ts
+++ b/src/coupon/coupon-issued/coupon-issued.controller.ts
@@ -1,0 +1,303 @@
+import {
+  Body,
+  Controller,
+  Get,
+  HttpStatus,
+  Post,
+  Query,
+  UseGuards,
+} from "@nestjs/common";
+import {
+  ApiBearerAuth,
+  ApiBody,
+  ApiConflictResponse,
+  ApiCreatedResponse,
+  ApiOkResponse,
+  ApiOperation,
+  ApiQuery,
+  ApiResponse,
+  ApiTags,
+  ApiUnauthorizedResponse,
+} from "@nestjs/swagger";
+import { CouponIssuedService } from "./coupon-issued.service";
+import { JwtAuthGuard } from "src/auth/security/auth.guard";
+import { CreateCouponIssueByUserDTO } from "../_dto/create-coupon-issue-by-user.dto";
+import { Payload } from "src/auth/security/user.payload.interface";
+import { User } from "src/auth/user.decorator";
+import { CreateLimitCouponIssueByUserDTO } from "../_dto/create-limit-coupon-issue-by-user.dto";
+import { ResponseCommonSuccessDTO } from "src/_common/_dto/common-success-response.dto";
+import { ResponseSuccessGetMyCouponListDTO } from "../_dto/reponse-success-get-my-coupon-list-dto";
+
+@Controller("coupon-issued")
+@ApiTags("coupon-issued")
+export class CouponIssuedController {
+  constructor(private readonly couponIssuedService: CouponIssuedService) {}
+
+  /**
+   * 유저별 일반 쿠폰 발행 생성(생성시 로그 생성)
+   */
+  @Post("general")
+  @ApiBearerAuth("accessToken")
+  @UseGuards(JwtAuthGuard)
+  @ApiOperation({
+    summary: "유저 일반쿠폰 발급",
+    description: "유저에게 특정 일반쿠폰을 발급해줍니다.",
+  })
+  @ApiBody({
+    description: "특정 쿠폰을 특정 유저에게 발급할때 사용되는 정보입니다.",
+    required: true,
+    type: CreateCouponIssueByUserDTO,
+  })
+  @ApiUnauthorizedResponse({
+    description: "로그인 하지 않은 경우",
+    example: {
+      message: "Unauthorized",
+      statusCode: HttpStatus.UNAUTHORIZED,
+    },
+  })
+  @ApiResponse({
+    status: HttpStatus.NOT_FOUND,
+    description: "유저 또는 쿠폰 정보가 존재하지 않을 때",
+    content: {
+      "application/json": {
+        examples: {
+          userNotFound: {
+            summary: "존재하지 않는 사용자",
+            value: {
+              statusCode: HttpStatus.NOT_FOUND,
+              message: "not existed user",
+              error: "Not Found",
+            },
+          },
+          couponNotFound: {
+            summary: "존재하지 않는 쿠폰",
+            value: {
+              statusCode: HttpStatus.NOT_FOUND,
+              message: "not existed coupon",
+              error: "Not Found",
+            },
+          },
+        },
+      },
+    },
+  })
+  @ApiResponse({
+    status: HttpStatus.BAD_REQUEST,
+    description: "잘못된 요청으로 인해서 발생하는 경우",
+    content: {
+      "application/json": {
+        examples: {
+          couponInactive: {
+            summary: "비활성화된 쿠폰인 경우",
+            value: {
+              statusCode: HttpStatus.BAD_REQUEST,
+              message: "coupon is not active.",
+              error: "Bad Request",
+            },
+          },
+          InvalidPeriodCoupon: {
+            summary: "쿠폰의 사용기간이 벗어나는 경우",
+            value: {
+              statusCode: HttpStatus.BAD_REQUEST,
+              message: "coupon is out of valid period.",
+              error: "Bad Request",
+            },
+          },
+          soldoutCoupon: {
+            summary: "선착순 쿠폰에서 쿠폰의 수량이 모두 소진된 경우",
+            value: {
+              statusCode: HttpStatus.BAD_REQUEST,
+              message: "sold out",
+              error: "Bad Request",
+            },
+          },
+          LimitedCoupon: {
+            summary: "일반 쿠폰발급인데 쿠폰이 선착순 발급인 경우",
+            value: {
+              statusCode: HttpStatus.BAD_REQUEST,
+              message: "coupon is limited",
+              error: "Bad Request",
+            },
+          },
+        },
+      },
+    },
+  })
+  @ApiConflictResponse({
+    description: "이미 발급된 쿠폰인 경우(1인 1매 제한)",
+    example: {
+      statusCode: HttpStatus.CONFLICT,
+      message: "Already issued",
+      error: "Conflict",
+    },
+  })
+  @ApiCreatedResponse({
+    description: "쿠폰 발급 성공",
+    example: {
+      message: "success",
+      statusCode: HttpStatus.CREATED,
+    },
+  })
+  async createCouponIssueByUser(
+    @Body() createCouponIssueByUserDto: CreateCouponIssueByUserDTO,
+    @User() user: Payload,
+  ): Promise<ResponseCommonSuccessDTO> {
+    return await this.couponIssuedService.createCouponIssueByUser(
+      createCouponIssueByUserDto,
+      user,
+    );
+  }
+
+  @Post("fcfs")
+  @ApiBearerAuth("accessToken")
+  @UseGuards(JwtAuthGuard)
+  @ApiOperation({
+    summary: "유저 선착순 쿠폰 발급",
+    description: "유저에게 특정 쿠폰을 선착순으로 발급해줍니다.",
+  })
+  @ApiBody({
+    description:
+      "특정 쿠폰을 특정 유저에게 선착순으로 발급할때 사용되는 정보입니다.",
+    required: true,
+    type: CreateLimitCouponIssueByUserDTO,
+  })
+  @ApiUnauthorizedResponse({
+    description: "로그인 하지 않은 경우",
+    example: {
+      message: "Unauthorized",
+      statusCode: HttpStatus.UNAUTHORIZED,
+    },
+  })
+  @ApiResponse({
+    status: HttpStatus.NOT_FOUND,
+    description: "유저 또는 쿠폰 정보가 존재하지 않을 때",
+    content: {
+      "application/json": {
+        examples: {
+          userNotFound: {
+            summary: "존재하지 않는 사용자",
+            value: {
+              statusCode: HttpStatus.NOT_FOUND,
+              message: "not existed user",
+              error: "Not Found",
+            },
+          },
+          couponNotFound: {
+            summary: "존재하지 않는 쿠폰",
+            value: {
+              statusCode: HttpStatus.NOT_FOUND,
+              message: "not existed coupon",
+              error: "Not Found",
+            },
+          },
+        },
+      },
+    },
+  })
+  @ApiResponse({
+    status: HttpStatus.BAD_REQUEST,
+    description: "잘못된 요청으로 인해서 발생하는 경우",
+    content: {
+      "application/json": {
+        examples: {
+          couponInactive: {
+            summary: "비활성화된 쿠폰인 경우",
+            value: {
+              statusCode: HttpStatus.BAD_REQUEST,
+              message: "coupon is not active.",
+              error: "Bad Request",
+            },
+          },
+          InvalidPeriodCoupon: {
+            summary: "쿠폰의 사용기간이 벗어나는 경우",
+            value: {
+              statusCode: HttpStatus.BAD_REQUEST,
+              message: "coupon is out of valid period.",
+              error: "Bad Request",
+            },
+          },
+          soldoutCoupon: {
+            summary: "선착순 쿠폰에서 쿠폰의 수량이 모두 소진된 경우",
+            value: {
+              statusCode: HttpStatus.BAD_REQUEST,
+              message: "sold out",
+              error: "Bad Request",
+            },
+          },
+          notLimitedCoupon: {
+            summary: "선착순 쿠폰발급인데 쿠폰이 발급제한이 없는 경우",
+            value: {
+              statusCode: HttpStatus.BAD_REQUEST,
+              message: "coupon is not limited",
+              error: "Bad Request",
+            },
+          },
+        },
+      },
+    },
+  })
+  @ApiConflictResponse({
+    description: "이미 발급된 쿠폰인 경우(1인 1매 제한)",
+    example: {
+      statusCode: HttpStatus.CONFLICT,
+      message: "Already issued",
+      error: "Conflict",
+    },
+  })
+  @ApiCreatedResponse({
+    description: "쿠폰 발급 성공",
+    example: {
+      message: "success",
+      statusCode: HttpStatus.CREATED,
+    },
+  })
+  async createLimitCouponIssueByUser(
+    @Body() createLimitCouponIssueByUser: CreateLimitCouponIssueByUserDTO,
+    @User() user: Payload,
+  ): Promise<ResponseCommonSuccessDTO> {
+    return await this.couponIssuedService.createLimitCouponIssueByUser(
+      createLimitCouponIssueByUser,
+      user,
+    );
+  }
+
+  @Get("my")
+  @ApiBearerAuth("accessToken")
+  @UseGuards(JwtAuthGuard)
+  @ApiOperation({
+    summary: "내 발급 쿠폰 목록",
+    description:
+      "로그인한 사용자의 발급 쿠폰(발급 이력 + 쿠폰 정보)을 최신순으로 반환합니다.",
+  })
+  @ApiQuery({
+    name: "page",
+    required: false,
+    example: 1,
+    description: "페이지(기본 1)",
+  })
+  @ApiQuery({
+    name: "limit",
+    required: false,
+    example: 10,
+    description: "페이지 크기(기본 10)",
+  })
+  @ApiUnauthorizedResponse({
+    description: "로그인하지 않은 경우",
+    example: { message: "Unauthorized", statusCode: HttpStatus.UNAUTHORIZED },
+  })
+  @ApiOkResponse({
+    description: "조회 성공",
+    type: ResponseSuccessGetMyCouponListDTO,
+  })
+  async getMyCoupons(
+    @User() user: Payload,
+    @Query("page") page = 1,
+    @Query("limit") limit = 10,
+  ): Promise<ResponseSuccessGetMyCouponListDTO> {
+    return this.couponIssuedService.getMyCoupons(
+      user,
+      Number(page),
+      Number(limit),
+    );
+  }
+}

--- a/src/coupon/coupon-issued/coupon-issued.service.ts
+++ b/src/coupon/coupon-issued/coupon-issued.service.ts
@@ -1,0 +1,255 @@
+import {
+  BadRequestException,
+  ConflictException,
+  HttpStatus,
+  Injectable,
+  InternalServerErrorException,
+  NotFoundException,
+} from "@nestjs/common";
+import { CouponIssuedLogEntity } from "entities/coupons/coupon-issued-log.entity";
+import { DataSource } from "typeorm";
+import { CreateCouponIssueByUserDTO } from "../_dto/create-coupon-issue-by-user.dto";
+import { UserService } from "src/user/user.service";
+import { CouponService } from "../coupon.service";
+import { ResponseCommonSuccessDTO } from "src/_common/_dto/common-success-response.dto";
+import { CouponEntity } from "entities/coupons/coupon.entity";
+import { Payload } from "src/auth/security/user.payload.interface";
+import { CreateLimitCouponIssueByUserDTO } from "../_dto/create-limit-coupon-issue-by-user.dto";
+import { CouponIssuedEntity } from "entities/coupons/coupon-issued.entity";
+
+@Injectable()
+export class CouponIssuedService {
+  constructor(
+    private readonly dataSource: DataSource,
+
+    private readonly userService: UserService,
+    private readonly couponService: CouponService,
+  ) {}
+
+  /**
+   * 일반 쿠폰 발행
+   * @param createCouponIssueByUserDto
+   * @returns
+   */
+  async createCouponIssueByUser(
+    createCouponIssueByUserDto: CreateCouponIssueByUserDTO,
+    user: Payload,
+  ): Promise<ResponseCommonSuccessDTO> {
+    const { couponId } = createCouponIssueByUserDto;
+
+    if (!user) throw new NotFoundException("not existed user");
+
+    const coupon = await this.couponService.findOneById(couponId);
+
+    if (!coupon) throw new NotFoundException("not existed coupon");
+    if (!coupon.isActive)
+      throw new BadRequestException("coupon is not active.");
+    if (coupon.isPeriodLimited) {
+      const now = new Date();
+      if (now < coupon.startedDt || now > coupon.endedDt) {
+        throw new BadRequestException("coupon is out of valid period.");
+      }
+    }
+    if (coupon.isIssuedLimited || coupon.totalCount !== null) {
+      throw new BadRequestException("coupon is limited");
+    }
+
+    const expiredDt = coupon.isPeriodLimited ? coupon.endedDt : null;
+
+    return this.dataSource.transaction(async (manager) => {
+      try {
+        //couponIssue에서 IGNORE로 에러로그 발생시키지 않게하기 위해 쿼리로 작성함
+        const couponIssue = await manager.query(
+          "INSERT IGNORE INTO `coupon_issued` (`userId`,`couponId`,`isUsed`,`expiredDt`) VALUES (?,?,?,?)",
+          [user.id, coupon.id, false, expiredDt],
+        );
+
+        // 중복이면 영향 0 (에러로그 없이 예외처리)
+        if ((couponIssue?.affectedRows ?? 0) === 0) {
+          await this.dataSource.manager.insert(CouponIssuedLogEntity, {
+            userId: user.id,
+            couponId: coupon.id,
+            action: "already",
+          });
+          throw new ConflictException("Already issued");
+        }
+
+        await manager.insert(CouponIssuedLogEntity, {
+          userId: user.id,
+          couponId: coupon.id,
+          action: "issued",
+        });
+
+        await manager.increment(
+          CouponEntity,
+          { id: coupon.id },
+          "issuedCount",
+          1,
+        );
+
+        return {
+          message: "success",
+          statusCode: HttpStatus.CREATED,
+        };
+      } catch (error) {
+        // 위에서 던진 애들은 그대로
+        if (
+          error instanceof BadRequestException ||
+          error instanceof NotFoundException ||
+          error instanceof ConflictException
+        )
+          throw error;
+
+        throw new InternalServerErrorException("fail issue coupon");
+      }
+    });
+  }
+
+  async createLimitCouponIssueByUser(
+    createLimitCouponIssueByUser: CreateLimitCouponIssueByUserDTO,
+    user: Payload,
+  ) {
+    const { couponId } = createLimitCouponIssueByUser;
+
+    if (!user) throw new NotFoundException("not existed user");
+
+    const coupon = await this.couponService.findOneById(couponId);
+
+    if (!coupon) throw new NotFoundException("not existed coupon");
+    if (!coupon.isActive)
+      throw new BadRequestException("coupon is not active.");
+    if (coupon.isPeriodLimited) {
+      const now = new Date();
+      if (now < coupon.startedDt || now > coupon.endedDt) {
+        throw new BadRequestException("coupon is out of valid period.");
+      }
+    }
+    if (!coupon.isIssuedLimited || coupon.totalCount === null) {
+      throw new BadRequestException("coupon is not limited");
+    }
+
+    const expiredDt = coupon.isPeriodLimited ? coupon.endedDt : null;
+
+    return await this.dataSource.transaction(
+      "READ COMMITTED",
+      async (manager) => {
+        try {
+          //couponIssue에서 IGNORE로 에러로그 발생시키지 않게하기 위해 쿼리로 작성함
+          const couponIssue = await manager.query(
+            "INSERT IGNORE INTO `coupon_issued` (`userId`,`couponId`,`isUsed`,`expiredDt`) VALUES (?,?,?,?)",
+            [user.id, coupon.id, false, expiredDt],
+          );
+
+          // 중복이면 영향 0 (에러로그 없이 예외처리)
+          if ((couponIssue?.affectedRows ?? 0) === 0) {
+            await this.dataSource.manager.insert(CouponIssuedLogEntity, {
+              userId: user.id,
+              couponId: coupon.id,
+              action: "already",
+            });
+            throw new ConflictException("Already issued");
+          }
+
+          const updateRes = await manager
+            .createQueryBuilder()
+            .update(CouponEntity)
+            .set({ issuedCount: () => "issuedCount + 1" })
+            .where("id = :id", { id: coupon.id })
+            .andWhere("totalCount IS NOT NULL")
+            .andWhere("issuedCount < totalCount")
+            .execute();
+
+          // 품절 → 보상 삭제 + 로그(outside tx) + 400
+          if (updateRes.affected !== 1) {
+            await manager
+              .createQueryBuilder()
+              .delete()
+              .from(CouponIssuedEntity)
+              .where("userId = :userId AND couponId = :couponId", {
+                userId: user.id,
+                couponId: coupon.id,
+              })
+              .execute();
+            await this.dataSource.manager.insert(CouponIssuedLogEntity, {
+              userId: user.id,
+              couponId: coupon.id,
+              action: "soldout",
+            });
+            throw new BadRequestException("sold out");
+          }
+
+          await manager.insert(CouponIssuedLogEntity, {
+            userId: user.id,
+            couponId: coupon.id,
+            action: "issued",
+          });
+
+          return {
+            message: "success",
+            statusCode: HttpStatus.CREATED,
+          };
+        } catch (error) {
+          if (
+            error instanceof BadRequestException &&
+            error.message === "sold out"
+          ) {
+            await this.dataSource.manager.insert(CouponIssuedLogEntity, {
+              userId: user.id,
+              couponId: coupon.id,
+              action: "soldout",
+            });
+            throw error;
+          }
+
+          if (
+            error instanceof BadRequestException ||
+            error instanceof NotFoundException ||
+            error instanceof ConflictException
+          )
+            throw error;
+
+          throw new InternalServerErrorException("fail issue coupon");
+        }
+      },
+    );
+  }
+
+  async getMyCoupons(user: Payload, page: number = 1, limit: number = 10) {
+    const couponsIssued = this.dataSource
+      .getRepository(CouponIssuedEntity)
+      .createQueryBuilder("ci")
+      .innerJoinAndSelect("ci.coupon", "c")
+      .where("ci.userId = :userId", { userId: user.id })
+      .orderBy("ci.issuedDt", "DESC")
+      .skip((page - 1) * limit)
+      .take(limit);
+
+    const [rows, totalCount] = await couponsIssued.getManyAndCount();
+
+    const coupon = rows.map((el) => {
+      return {
+        issuedId: el.id,
+        isUsed: el.isUsed,
+        expiredDt: el.expiredDt ? el.expiredDt.toISOString() : null,
+        couponId: el.coupon.id,
+        code: el.coupon.code,
+        name: el.coupon.name,
+        minPrice: el.coupon.minPrice,
+        discountType: el.coupon.discountType,
+        discountValue: el.coupon.discountValue,
+        isActive: el.coupon.isActive,
+        startedDt: el.coupon.startedDt
+          ? el.coupon.startedDt.toDateString()
+          : null,
+        endedDt: el.coupon.endedDt ? el.coupon.endedDt.toDateString() : null,
+      };
+    });
+
+    return {
+      coupons: coupon,
+      totalCount,
+      currPage: page,
+      totalPage: Math.ceil(totalCount / limit),
+    };
+  }
+}

--- a/src/coupon/coupon.controller.ts
+++ b/src/coupon/coupon.controller.ts
@@ -1,0 +1,247 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  HttpStatus,
+  Param,
+  Post,
+  Put,
+  Query,
+  UseGuards,
+} from "@nestjs/common";
+import { CouponService } from "./coupon.service";
+import {
+  ApiBearerAuth,
+  ApiBody,
+  ApiConflictResponse,
+  ApiCreatedResponse,
+  ApiNotFoundResponse,
+  ApiOkResponse,
+  ApiOperation,
+  ApiParam,
+  ApiQuery,
+  ApiTags,
+  ApiUnauthorizedResponse,
+} from "@nestjs/swagger";
+import { JwtAuthGuard } from "src/auth/security/auth.guard";
+import { CreateCouponDTO } from "./_dto/create-coupon.dto";
+import {
+  ResponseCreateCouponDataDTO,
+  ResponseSuccessCreateCoupon,
+} from "./_dto/response-success-create-coupon.dto";
+import { User } from "src/auth/user.decorator";
+import { Payload } from "src/auth/security/user.payload.interface";
+import { instanceToPlain } from "class-transformer";
+import { ResponseCommonSuccessDTO } from "src/_common/_dto/common-success-response.dto";
+import { UpdateCouponDTO } from "./_dto/update-coupon.dto";
+import { ResponseSuccessGetCouponListDTO } from "./_dto/response-success-get-coupon-list.dto";
+import { ResponseSuccessGetCouponDTO } from "./_dto/response-success-get-coupon.dto";
+
+@Controller("coupon")
+@ApiTags("coupon")
+export class CouponContorller {
+  constructor(private readonly couponService: CouponService) {}
+
+  @Post()
+  @ApiBearerAuth("accessToken")
+  @UseGuards(JwtAuthGuard)
+  @ApiOperation({
+    summary: "쿠폰 생성",
+    description: `
+      쿠폰을 생성합니다.
+      - 쿠폰 코드는 클라이언트에서 별도로 설정된 값이 아니면 문자 + 숫자 조합의 7개 문자열로 코드가 자동생성됩니다.
+    `,
+  })
+  @ApiBody({
+    type: CreateCouponDTO,
+    description: "쿠폰 생성 필요 정보",
+  })
+  @ApiUnauthorizedResponse({
+    description: "로그인 하지 않은 경우",
+    example: {
+      message: "Unauthorized",
+      statusCode: HttpStatus.UNAUTHORIZED,
+    },
+  })
+  @ApiConflictResponse({
+    description: "이미 존재하는 쿠폰 코드 입력시",
+    example: {
+      message: "already exist coupon code",
+      error: "Conflict",
+      statusCode: HttpStatus.CONFLICT,
+    },
+  })
+  @ApiCreatedResponse({
+    description: "쿠폰 생성 성공",
+    type: ResponseSuccessCreateCoupon,
+  })
+  async createCoupon(
+    @Body() createCouponDto: CreateCouponDTO,
+    @User() user: Payload,
+  ): Promise<ResponseSuccessCreateCoupon> {
+    const couponData = await this.couponService.createCoupon(
+      createCouponDto,
+      user,
+    );
+    return {
+      message: "success",
+      statusCode: HttpStatus.CREATED,
+      data: instanceToPlain(couponData) as ResponseCreateCouponDataDTO,
+    };
+  }
+
+  @Delete(":id")
+  @ApiBearerAuth("accessToken")
+  @UseGuards(JwtAuthGuard)
+  @ApiOperation({
+    summary: "쿠폰 삭제",
+    description: "쿠폰을 삭제합니다.",
+  })
+  @ApiUnauthorizedResponse({
+    description: "로그인 하지 않은 경우",
+    example: {
+      message: "Unauthorized",
+      statusCode: HttpStatus.UNAUTHORIZED,
+    },
+  })
+  @ApiNotFoundResponse({
+    description: "존재하지 않는 쿠폰 정보일때",
+    example: {
+      message: "not eixst coupon info",
+      error: "Not Found",
+      statusCode: HttpStatus.NOT_FOUND,
+    },
+  })
+  @ApiOkResponse({
+    description: "쿠폰정보 삭제 성공",
+    type: ResponseCommonSuccessDTO,
+  })
+  async deleteCoupon(
+    @Param("id") id: number,
+  ): Promise<ResponseCommonSuccessDTO> {
+    return await this.couponService.deleteCoupon(id);
+  }
+
+  @Put(":id")
+  @ApiBearerAuth("accessToken")
+  @UseGuards(JwtAuthGuard)
+  @ApiOperation({
+    summary: "쿠폰 정보 수정",
+    description: "쿠폰의 정보를 수정합니다.",
+  })
+  @ApiParam({
+    name: "id",
+    required: true,
+    description: "조회할 쿠폰의 ID",
+    example: 1,
+  })
+  @ApiBody({
+    type: UpdateCouponDTO,
+    description: "수정할 쿠폰 정보",
+  })
+  @ApiUnauthorizedResponse({
+    description: "로그인 하지 않은 경우",
+    example: {
+      message: "Unauthorized",
+      statusCode: HttpStatus.UNAUTHORIZED,
+    },
+  })
+  @ApiConflictResponse({
+    description: "이미 존재하는 쿠폰 코드 입력시",
+    example: {
+      message: "already existed coupon code",
+      error: "Conflict",
+      statusCode: HttpStatus.CONFLICT,
+    },
+  })
+  @ApiNotFoundResponse({
+    description: "존재하지 않는 쿠폰 정보일때",
+    example: {
+      message: "not eixst coupon info",
+      error: "Not Found",
+      statusCode: HttpStatus.NOT_FOUND,
+    },
+  })
+  @ApiOkResponse({
+    description: "쿠폰정보 수정 성공",
+    type: ResponseCommonSuccessDTO,
+  })
+  async updateCoupon(
+    @Param("id") id: number,
+    @Body() updateCouponDto: UpdateCouponDTO,
+  ): Promise<ResponseCommonSuccessDTO> {
+    return await this.couponService.updateCoupon(id, updateCouponDto);
+  }
+
+  @Get(":id")
+  @ApiBearerAuth("accessToken")
+  @UseGuards(JwtAuthGuard)
+  @ApiOperation({
+    summary: "쿠폰 단건 조회",
+    description: "쿠폰 단건 정보를 조회합니다.",
+  })
+  @ApiParam({
+    name: "id",
+    required: true,
+    description: "조회할 쿠폰의 ID",
+    example: 1,
+  })
+  @ApiNotFoundResponse({
+    description: "존재하지 않는 쿠폰 정보일때",
+    example: {
+      message: "not eixst coupon info",
+      error: "Not Found",
+      statusCode: HttpStatus.NOT_FOUND,
+    },
+  })
+  @ApiOkResponse({
+    description: "쿠폰 단건 조회 성공",
+    type: ResponseSuccessGetCouponDTO,
+  })
+  async getCoupon(
+    @Param("id") id: number,
+  ): Promise<ResponseSuccessGetCouponDTO> {
+    return await this.couponService.getCoupon(id);
+  }
+
+  @Get()
+  @ApiBearerAuth("accessToken")
+  @UseGuards(JwtAuthGuard)
+  @ApiOperation({
+    summary: "쿠폰 목록 조회",
+    description: "쿠폰 목록을 페이지네이션 방식으로 조회합니다.",
+  })
+  @ApiQuery({
+    name: "page",
+    required: false,
+    type: Number,
+    example: 1,
+    description: "조회할 페이지 번호 (기본값: 1)",
+  })
+  @ApiQuery({
+    name: "limit",
+    required: false,
+    type: Number,
+    example: 10,
+    description: "페이지당 항목 수 (기본값: 10)",
+  })
+  @ApiQuery({
+    name: "orderBy",
+    required: false,
+    enum: ["ASC", "DESC"],
+    example: "DESC",
+    description: "정렬 순서 (기본값: DESC)",
+  })
+  @ApiOkResponse({
+    description: "쿠폰 목록 조회 성공",
+    type: ResponseSuccessGetCouponListDTO,
+  })
+  async getCouponList(
+    @Query("page") page: number = 1,
+    @Query("limit") limit: number = 10,
+    @Query("orderBy") orderBy: "DESC" | "ASC" = "DESC",
+  ): Promise<ResponseSuccessGetCouponListDTO> {
+    return await this.couponService.getCouponList(page, limit, orderBy);
+  }
+}

--- a/src/coupon/coupon.module.ts
+++ b/src/coupon/coupon.module.ts
@@ -1,0 +1,24 @@
+import { Module } from "@nestjs/common";
+import { CouponContorller } from "./coupon.controller";
+import { CouponService } from "./coupon.service";
+import { TypeOrmModule } from "@nestjs/typeorm";
+import { CouponEntity } from "entities/coupons/coupon.entity";
+import { CouponIssuedEntity } from "entities/coupons/coupon-issued.entity";
+import { CouponIssuedLogEntity } from "entities/coupons/coupon-issued-log.entity";
+import { CouponIssuedController } from "./coupon-issued/coupon-issued.controller";
+import { CouponIssuedService } from "./coupon-issued/coupon-issued.service";
+import { UserModule } from "src/user/user.module";
+
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([
+      CouponEntity,
+      CouponIssuedEntity,
+      CouponIssuedLogEntity,
+    ]),
+    UserModule,
+  ],
+  controllers: [CouponContorller, CouponIssuedController],
+  providers: [CouponService, CouponIssuedService],
+})
+export class CouponModule {}

--- a/src/coupon/coupon.service.ts
+++ b/src/coupon/coupon.service.ts
@@ -1,0 +1,162 @@
+import {
+  ConflictException,
+  HttpStatus,
+  Injectable,
+  NotFoundException,
+} from "@nestjs/common";
+import { DataSource, Repository } from "typeorm";
+import { CreateCouponDTO } from "./_dto/create-coupon.dto";
+import { Payload } from "src/auth/security/user.payload.interface";
+import { CommonUtil } from "src/_common/common.util";
+import { CouponEntity } from "entities/coupons/coupon.entity";
+import { InjectRepository } from "@nestjs/typeorm";
+import { ResponseCommonSuccessDTO } from "src/_common/_dto/common-success-response.dto";
+import { UpdateCouponDTO } from "./_dto/update-coupon.dto";
+import { ResponseSuccessGetCouponListDTO } from "./_dto/response-success-get-coupon-list.dto";
+import { ResponseSuccessGetCouponDTO } from "./_dto/response-success-get-coupon.dto";
+
+@Injectable()
+export class CouponService {
+  private strings =
+    "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ01234567890";
+  constructor(
+    private readonly dataSource: DataSource,
+    private readonly commonUtil: CommonUtil,
+
+    @InjectRepository(CouponEntity)
+    private readonly couponRepository: Repository<CouponEntity>,
+  ) {}
+
+  async createCoupon(
+    createCouponDto: CreateCouponDTO,
+    user: Payload,
+  ): Promise<CouponEntity> {
+    const { code, ...restDto } = createCouponDto;
+
+    if (code) {
+      const existCouponCode = await this.couponRepository.findOne({
+        where: { code },
+      });
+      if (existCouponCode) {
+        throw new ConflictException("already exist coupon code");
+      }
+    }
+
+    const couponCode = await this.uniqueCouponCode(code);
+
+    const coupon = this.couponRepository.create({
+      code: couponCode,
+      issuedUserId: user.id,
+      ...restDto,
+    });
+
+    const savedCoupon = await this.couponRepository.save(coupon);
+
+    return savedCoupon;
+  }
+
+  async deleteCoupon(id: number): Promise<ResponseCommonSuccessDTO> {
+    const couponInfo = await this.findOneById(id);
+
+    if (!couponInfo) {
+      throw new NotFoundException("not eixst coupon info");
+    }
+
+    await this.couponRepository.softDelete({ id });
+
+    return {
+      message: "success",
+      statusCode: HttpStatus.OK,
+    };
+  }
+
+  async updateCoupon(
+    id: number,
+    updateCouponDto: UpdateCouponDTO,
+  ): Promise<ResponseCommonSuccessDTO> {
+    const { ...restParam } = updateCouponDto;
+    const couponInfo = await this.findOneById(id);
+
+    if (!couponInfo) {
+      throw new NotFoundException("not eixst coupon info");
+    }
+
+    const code = updateCouponDto.code;
+    if (code && code !== couponInfo.code) {
+      const existedCode = await this.couponRepository.findOne({
+        where: { code: updateCouponDto.code },
+        withDeleted: true,
+      });
+      if (existedCode)
+        throw new ConflictException("already existed coupon code");
+    }
+
+    await this.couponRepository.update({ id }, { ...restParam });
+
+    return {
+      message: "success",
+      statusCode: HttpStatus.OK,
+    };
+  }
+
+  async getCoupon(id: number): Promise<ResponseSuccessGetCouponDTO> {
+    const couponInfo = await this.findOneById(id);
+
+    if (!couponInfo) {
+      throw new NotFoundException("not eixst coupon info");
+    }
+
+    delete couponInfo.deletedDt;
+    return couponInfo;
+  }
+
+  async getCouponList(
+    page: number = 1,
+    limit: number = 10,
+    orderBy: "DESC" | "ASC" = "DESC",
+  ): Promise<ResponseSuccessGetCouponListDTO> {
+    const [coupons, totalCount] = await this.couponRepository.findAndCount({
+      skip: (page - 1) * limit,
+      take: limit,
+      order: { createdDt: orderBy },
+    });
+
+    const refinedCopupons = coupons.map(
+      ({ issuedUserId, deletedDt, user, ...rest }) => rest,
+    );
+
+    return {
+      data: refinedCopupons,
+      totalCount,
+      currPage: page,
+      totalPage: Math.ceil(totalCount / limit),
+    };
+  }
+
+  private async uniqueCouponCode(code: string): Promise<string> {
+    let unique = false;
+    let finalCode = code;
+
+    while (!unique) {
+      const exists = await this.couponRepository.findOne({
+        where: { code: finalCode },
+        withDeleted: true,
+      });
+
+      if (!exists) {
+        unique = true;
+      } else {
+        finalCode = this.commonUtil.generateRandomString(7, this.strings);
+      }
+    }
+
+    return finalCode;
+  }
+
+  async findOneById(id: number): Promise<CouponEntity> {
+    return await this.couponRepository.findOne({
+      where: { id },
+      withDeleted: false, //삭제된 쿠폰들에 대한 정보까지에 대해서는 필요한 경우 withDeleted: true,
+    });
+  }
+}

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -123,4 +123,12 @@ export class UserService {
       message: "success",
     };
   }
+
+  async findOneById(id: number) {
+    return await this.userRepository.findOne({
+      select: ["id", "email", "name", "userUuid", "createdDt", "updatedDt"],
+      where: { id },
+      withDeleted: false,
+    });
+  }
 }


### PR DESCRIPTION
  - 쿠폰 생성
  - 쿠폰 목록 조회
  - 쿠폰 단건(상세) 조회
  - 쿠폰 정보 수정
  - 쿠폰 삭제
  - 내 발급 쿠폰 목록 조회
  - 쿠폰 일반 발급(무제한)
  - 쿠폰 선착순 발급
    - 동시성 처리
      1. 트랜잭션 + READ COMMITTED 
          - 각 요청을 트랜잭션으로 감싸 일관된 상태 보장. 
          - READ COMMITTED로 실무 기본 수준의 격리 확보(성능/락 경합 균형).
      2. 중복 발급 방지: INSERT IGNORE
          - INSERT IGNORE INTO coupon_issued (userId, couponId, ...)
          - (userId, couponId) 유니크 인덱스에서 충돌 시 DB 에러 없이 영향 0행으로 반환 → 에러로그 없음. 
          - 영향 0이면 ConflictException("Already issued")로 비즈니스 예외 반환. 
          - 👉 idempotent한 재시도/중복 요청 처리 
       3. 재고 증가의 원자성: 조건부 UPDATE
          - UPDATE coupon SET issuedCount = issuedCount + 1 WHERE id = :id AND totalCount IS NOT NULL AND issuedCount < totalCount; - 검사+증가를 단일 쿼리로 수행 → 레이스 컨디션 차단.
          - affected !== 1 이면 품절(sold out) 로 판단. 
      4. 보상 처리(Compensation) 
          - 품절임이 뒤늦게 판명되면(업데이트 영향 0) 
          - 직전에 삽입한 coupon_issued 레코드 삭제 
          - coupon_issued_log에 "soldout" 기록
          -  - BadRequestException("sold out") 반환
          - 👉 “재고 초과 시 삽입분 되돌리기”로 정합성 유지           
       5. 업무 로그 분리
          - 발급 성공: "issued"
          - 중복 발급: "already" (INSERT IGNORE 영향 0인 경우)
          - 품절: "soldout"
          - 품절/중복 케이스는 DB 에러로그 없이 도메인 로그로만 남김.

      - 전제 조건(스키마/인덱스) 
          - coupon_issued (userId, couponId) UNIQUE (1인 1매 보장) 
          - 쿼리 성능을 위해 coupon_issued.userId, coupon_issued.couponId 인덱스 확인
          - coupon.totalCount, coupon.issuedCount 정수 컬럼(널 허용 정책 명확화)

    - 실패/경합 시나리오 대응
          - 동시 다발적 발급 시: 
               - 한 요청만 조건부 UPDATE 성공 → 나머지는 영향 0 → sold out 보상 처리. 
               - 중복 재시도/리프레시 이슈: - INSERT IGNORE 영향 0 → Already issued 반환(에러로그 없음). 
               - 기간/활성 상태: - 사전 검증(isActive, 기간 유효성)으로 불필요한 DB 갱신 방지.