### PR TITLE
feat(accounting): add rule CRUD and journal rebuild workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,8 +349,13 @@ http://localhost/api/docs
 
 - `POST /account/sync/notion` - 노션 거래 동기화
 - `POST /account/journal/generate` - 분개 생성
+- `POST /account/journal/rebuild` - 규칙 기반 분개 재생성 (소급/비소급)
 - `GET /account/inbox` - 검토 필요 거래 조회
 - `GET /account/export/excel` - 분개장/시산표 엑셀 다운로드
+- `GET /account/rule` - 분개 규칙 조회
+- `POST /account/rule` - 분개 규칙 생성
+- `PATCH /account/rule/:id` - 분개 규칙 수정
+- `DELETE /account/rule/:id` - 분개 규칙 삭제
 
 ## WebSocket Testing / 웹소켓 테스트
 

--- a/entities/accounting/accounting.enums.ts
+++ b/entities/accounting/accounting.enums.ts
@@ -13,6 +13,8 @@ export enum AccountingTransactionStatus {
   Ready = "READY",
   Review = "REVIEW",
   Processed = "PROCESSED",
+  Corrected = "CORRECTED",
+  Cancelled = "CANCELLED",
 }
 
 export enum AccountingVatMode {

--- a/entities/accounting/rule.entity.ts
+++ b/entities/accounting/rule.entity.ts
@@ -2,6 +2,7 @@ import {
   Column,
   CreateDateColumn,
   Entity,
+  Index,
   PrimaryGeneratedColumn,
   UpdateDateColumn,
 } from "typeorm";
@@ -11,6 +12,9 @@ import {
 } from "./accounting.enums";
 
 @Entity("accounting_rule")
+@Index("uniq_accounting_rule_type_category", ["type", "category"], {
+  unique: true,
+})
 export class AccountingRuleEntity {
   @PrimaryGeneratedColumn("increment", {
     name: "id",

--- a/entities/accounting/transaction.entity.ts
+++ b/entities/accounting/transaction.entity.ts
@@ -2,6 +2,7 @@ import {
   Column,
   CreateDateColumn,
   Entity,
+  Index,
   OneToMany,
   PrimaryGeneratedColumn,
   UpdateDateColumn,
@@ -14,6 +15,7 @@ import {
 import { AccountingJournalEntryEntity } from "./journal-entry.entity";
 
 @Entity("accounting_transaction")
+@Index("idx_accounting_transaction_notionPageId", ["notionPageId"])
 export class AccountingTransactionEntity {
   @PrimaryGeneratedColumn("increment", {
     name: "id",
@@ -25,11 +27,51 @@ export class AccountingTransactionEntity {
   @Column("varchar", {
     name: "notionPageId",
     length: 128,
-    unique: true,
     nullable: false,
     comment: "노션 페이지 아이디",
   })
   notionPageId: string;
+
+  @Column("int", {
+    name: "revision",
+    unsigned: true,
+    nullable: false,
+    default: 1,
+    comment: "정정 버전",
+  })
+  revision: number;
+
+  @Column("int", {
+    name: "correctedFromId",
+    unsigned: true,
+    nullable: true,
+    comment: "정정 원거래 아이디",
+  })
+  correctedFromId: number | null;
+
+  @Column("varchar", {
+    name: "correctionReason",
+    length: 500,
+    nullable: true,
+    comment: "정정 사유",
+  })
+  correctionReason: string | null;
+
+  @Column("varchar", {
+    name: "cancellationReason",
+    length: 500,
+    nullable: true,
+    comment: "취소 사유",
+  })
+  cancellationReason: string | null;
+
+  @Column("datetime", {
+    name: "notionLastEditedAt",
+    precision: 0,
+    nullable: true,
+    comment: "노션 최종 수정일",
+  })
+  notionLastEditedAt: Date | null;
 
   @Column("date", {
     name: "date",

--- a/src/_migrations/1769669872345-add-accounting-revision-and-rule-unique.ts
+++ b/src/_migrations/1769669872345-add-accounting-revision-and-rule-unique.ts
@@ -1,0 +1,67 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class AddAccountingRevisionAndRuleUnique1769669872345
+  implements MigrationInterface
+{
+  name = "AddAccountingRevisionAndRuleUnique1769669872345";
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      "ALTER TABLE `accounting_transaction` DROP INDEX `IDX_7f41699065c686d82a52c462e6`",
+    );
+    await queryRunner.query(
+      "ALTER TABLE `accounting_transaction` ADD `revision` int UNSIGNED NOT NULL DEFAULT 1 COMMENT '정정 버전'",
+    );
+    await queryRunner.query(
+      "ALTER TABLE `accounting_transaction` ADD `correctedFromId` int UNSIGNED NULL COMMENT '정정 원거래 아이디'",
+    );
+    await queryRunner.query(
+      "ALTER TABLE `accounting_transaction` ADD `correctionReason` varchar(500) NULL COMMENT '정정 사유'",
+    );
+    await queryRunner.query(
+      "ALTER TABLE `accounting_transaction` ADD `cancellationReason` varchar(500) NULL COMMENT '취소 사유'",
+    );
+    await queryRunner.query(
+      "ALTER TABLE `accounting_transaction` ADD `notionLastEditedAt` datetime(0) NULL COMMENT '노션 최종 수정일'",
+    );
+    await queryRunner.query(
+      "ALTER TABLE `accounting_transaction` MODIFY `status` enum ('READY','REVIEW','PROCESSED','CORRECTED','CANCELLED') NOT NULL COMMENT '처리 상태' DEFAULT 'READY'",
+    );
+    await queryRunner.query(
+      "CREATE INDEX `idx_accounting_transaction_notionPageId` ON `accounting_transaction` (`notionPageId`)",
+    );
+    await queryRunner.query(
+      "CREATE UNIQUE INDEX `uniq_accounting_rule_type_category` ON `accounting_rule` (`type`, `category`)",
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      "DROP INDEX `uniq_accounting_rule_type_category` ON `accounting_rule`",
+    );
+    await queryRunner.query(
+      "DROP INDEX `idx_accounting_transaction_notionPageId` ON `accounting_transaction`",
+    );
+    await queryRunner.query(
+      "ALTER TABLE `accounting_transaction` MODIFY `status` enum ('READY','REVIEW','PROCESSED') NOT NULL COMMENT '처리 상태' DEFAULT 'READY'",
+    );
+    await queryRunner.query(
+      "ALTER TABLE `accounting_transaction` DROP COLUMN `notionLastEditedAt`",
+    );
+    await queryRunner.query(
+      "ALTER TABLE `accounting_transaction` DROP COLUMN `cancellationReason`",
+    );
+    await queryRunner.query(
+      "ALTER TABLE `accounting_transaction` DROP COLUMN `correctionReason`",
+    );
+    await queryRunner.query(
+      "ALTER TABLE `accounting_transaction` DROP COLUMN `correctedFromId`",
+    );
+    await queryRunner.query(
+      "ALTER TABLE `accounting_transaction` DROP COLUMN `revision`",
+    );
+    await queryRunner.query(
+      "CREATE UNIQUE INDEX `IDX_7f41699065c686d82a52c462e6` ON `accounting_transaction` (`notionPageId`)",
+    );
+  }
+}

--- a/src/accounting/accounting.controller.ts
+++ b/src/accounting/accounting.controller.ts
@@ -3,16 +3,24 @@ import {
   Controller,
   Get,
   HttpStatus,
+  Param,
+  ParseIntPipe,
+  Patch,
   Post,
   Query,
   Res,
+  Delete,
 } from "@nestjs/common";
 import { ApiOkResponse, ApiOperation, ApiTags } from "@nestjs/swagger";
 import { Response } from "express";
 import { AccountingService } from "./accounting.service";
 import { GenerateJournalDto } from "./dto/generate-journal.dto";
+import { RebuildJournalDto } from "./dto/rebuild-journal.dto";
 import { InboxQueryDto } from "./dto/inbox.query.dto";
 import { ExportExcelQueryDto } from "./dto/export-excel.query.dto";
+import { RuleQueryDto } from "./dto/rule-query.dto";
+import { CreateRuleDto } from "./dto/create-rule.dto";
+import { UpdateRuleDto } from "./dto/update-rule.dto";
 
 @Controller("/account")
 @ApiTags("회계 자동화")
@@ -51,6 +59,24 @@ export class AccountingController {
   })
   async generateJournal(@Body() payload: GenerateJournalDto) {
     const result = await this.accountingService.generateJournalEntries(payload);
+
+    return {
+      message: "success",
+      statusCode: HttpStatus.OK,
+      ...result,
+    };
+  }
+
+  @Post("journal/rebuild")
+  @ApiOperation({
+    summary: "분개 재생성",
+    description: "규칙 기준으로 분개를 재생성합니다.",
+  })
+  @ApiOkResponse({
+    description: "분개 재생성 결과",
+  })
+  async rebuildJournal(@Body() payload: RebuildJournalDto) {
+    const result = await this.accountingService.rebuildJournalEntries(payload);
 
     return {
       message: "success",
@@ -99,5 +125,80 @@ export class AccountingController {
       "attachment; filename=accounting-export.xlsx",
     );
     response.status(HttpStatus.OK).send(buffer);
+  }
+
+  @Get("rule")
+  @ApiOperation({
+    summary: "분개 규칙 조회",
+    description: "분개 규칙 목록을 조회합니다.",
+  })
+  @ApiOkResponse({
+    description: "규칙 목록",
+  })
+  async getRules(@Query() query: RuleQueryDto) {
+    const result = await this.accountingService.getRules(query);
+
+    return {
+      message: "success",
+      statusCode: HttpStatus.OK,
+      ...result,
+    };
+  }
+
+  @Post("rule")
+  @ApiOperation({
+    summary: "분개 규칙 생성",
+    description: "분개 규칙을 생성합니다.",
+  })
+  @ApiOkResponse({
+    description: "규칙 생성 결과",
+  })
+  async createRule(@Body() payload: CreateRuleDto) {
+    const rule = await this.accountingService.createRule(payload);
+
+    return {
+      message: "success",
+      statusCode: HttpStatus.OK,
+      rule,
+    };
+  }
+
+  @Patch("rule/:id")
+  @ApiOperation({
+    summary: "분개 규칙 수정",
+    description: "분개 규칙을 수정합니다.",
+  })
+  @ApiOkResponse({
+    description: "규칙 수정 결과",
+  })
+  async updateRule(
+    @Param("id", ParseIntPipe) id: number,
+    @Body() payload: UpdateRuleDto,
+  ) {
+    const rule = await this.accountingService.updateRule(id, payload);
+
+    return {
+      message: "success",
+      statusCode: HttpStatus.OK,
+      rule,
+    };
+  }
+
+  @Delete("rule/:id")
+  @ApiOperation({
+    summary: "분개 규칙 삭제",
+    description: "분개 규칙을 삭제합니다.",
+  })
+  @ApiOkResponse({
+    description: "규칙 삭제 결과",
+  })
+  async deleteRule(@Param("id", ParseIntPipe) id: number) {
+    const result = await this.accountingService.deleteRule(id);
+
+    return {
+      message: "success",
+      statusCode: HttpStatus.OK,
+      ...result,
+    };
   }
 }

--- a/src/accounting/accounting.service.ts
+++ b/src/accounting/accounting.service.ts
@@ -1,6 +1,18 @@
-import { BadRequestException, Injectable } from "@nestjs/common";
+import {
+  BadRequestException,
+  Injectable,
+  NotFoundException,
+} from "@nestjs/common";
 import { InjectRepository } from "@nestjs/typeorm";
-import { Between, LessThanOrEqual, MoreThanOrEqual, Repository } from "typeorm";
+import {
+  Between,
+  In,
+  LessThanOrEqual,
+  MoreThanOrEqual,
+  Not,
+  QueryFailedError,
+  Repository,
+} from "typeorm";
 import { Client } from "@notionhq/client";
 import * as ExcelJS from "exceljs";
 import {
@@ -18,6 +30,13 @@ import { NotionTransactionDto } from "./dto/notion-transaction.dto";
 import { GenerateJournalDto } from "./dto/generate-journal.dto";
 import { ExportExcelQueryDto } from "./dto/export-excel.query.dto";
 import { InboxQueryDto } from "./dto/inbox.query.dto";
+import { RuleQueryDto } from "./dto/rule-query.dto";
+import { CreateRuleDto } from "./dto/create-rule.dto";
+import { UpdateRuleDto } from "./dto/update-rule.dto";
+import {
+  JournalRebuildMode,
+  RebuildJournalDto,
+} from "./dto/rebuild-journal.dto";
 
 type TrialBalanceRow = {
   account: string;
@@ -47,20 +66,82 @@ export class AccountingService {
     category: "분류",
     counterparty: "거래처",
     memo: "메모",
+    correctionReason: "정정 사유",
+    cancellationReason: "취소 사유",
   };
 
   async syncNotion() {
-    const { transactions, skippedCount } = await this.fetchNotionTransactions();
+    const { transactions, skippedCount, notionPageIds } =
+      await this.fetchNotionTransactions();
     const synced = [] as AccountingTransactionEntity[];
+    let correctedCount = 0;
+    let cancelledCount = 0;
+    let unchangedCount = 0;
 
     for (const transaction of transactions) {
       const existing = await this.transactionRepository.findOne({
         where: { notionPageId: transaction.notionPageId },
+        order: { revision: "DESC" },
       });
+      const lastEditedAt = transaction.notionLastEditedAt
+        ? new Date(transaction.notionLastEditedAt)
+        : null;
+      const isArchived = Boolean(transaction.notionArchived);
+
+      if (existing?.notionLastEditedAt && lastEditedAt) {
+        if (existing.notionLastEditedAt.getTime() === lastEditedAt.getTime()) {
+          unchangedCount += 1;
+          continue;
+        }
+      }
+
+      if (isArchived) {
+        if (existing) {
+          existing.status = AccountingTransactionStatus.Cancelled;
+          existing.cancellationReason =
+            transaction.cancellationReason ?? "notion_archived";
+          existing.notionLastEditedAt = lastEditedAt;
+          await this.transactionRepository.save(existing);
+        } else {
+          const cancelledEntity = this.transactionRepository.create({
+            notionPageId: transaction.notionPageId,
+            revision: 1,
+            correctedFromId: null,
+            notionLastEditedAt: lastEditedAt,
+            date: new Date(transaction.date),
+            type: transaction.type,
+            amount: this.formatAmount(transaction.amount),
+            amountIncludesVat: transaction.amountIncludesVat,
+            vatType: transaction.vatType,
+            category: transaction.category,
+            counterparty: transaction.counterparty ?? null,
+            memo: transaction.memo ?? null,
+            status: AccountingTransactionStatus.Cancelled,
+            error: null,
+            correctionReason: null,
+            cancellationReason:
+              transaction.cancellationReason ?? "notion_archived",
+          });
+          await this.transactionRepository.save(cancelledEntity);
+        }
+        cancelledCount += 1;
+        continue;
+      }
+
+      if (existing) {
+        existing.status = AccountingTransactionStatus.Corrected;
+        existing.correctionReason =
+          transaction.correctionReason ?? "notion_updated";
+        existing.notionLastEditedAt = lastEditedAt;
+        await this.transactionRepository.save(existing);
+        correctedCount += 1;
+      }
 
       const entity = this.transactionRepository.create({
-        id: existing?.id,
         notionPageId: transaction.notionPageId,
+        revision: existing ? existing.revision + 1 : 1,
+        correctedFromId: existing?.id ?? null,
+        notionLastEditedAt: lastEditedAt,
         date: new Date(transaction.date),
         type: transaction.type,
         amount: this.formatAmount(transaction.amount),
@@ -71,14 +152,43 @@ export class AccountingService {
         memo: transaction.memo ?? null,
         status: AccountingTransactionStatus.Ready,
         error: null,
+        correctionReason: null,
+        cancellationReason: null,
       });
 
       synced.push(await this.transactionRepository.save(entity));
     }
 
+    if (notionPageIds.size > 0) {
+      const activeTransactions = await this.transactionRepository.find({
+        where: {
+          status: Not(
+            In([
+              AccountingTransactionStatus.Cancelled,
+              AccountingTransactionStatus.Corrected,
+            ]),
+          ),
+        },
+      });
+
+      for (const transaction of activeTransactions) {
+        if (notionPageIds.has(transaction.notionPageId)) {
+          continue;
+        }
+
+        transaction.status = AccountingTransactionStatus.Cancelled;
+        transaction.cancellationReason = "notion_deleted";
+        await this.transactionRepository.save(transaction);
+        cancelledCount += 1;
+      }
+    }
+
     return {
       syncedCount: synced.length,
       skippedCount,
+      correctedCount,
+      cancelledCount,
+      unchangedCount,
     };
   }
 
@@ -110,30 +220,10 @@ export class AccountingService {
         continue;
       }
 
-      const journalLines = this.buildJournalLines(transaction, rule);
-      const isBalanced = this.isBalanced(journalLines);
-
-      const entry = this.journalEntryRepository.create({
-        transactionId: transaction.id,
-        memo: transaction.memo ?? null,
-        isBalanced,
-        lines: journalLines,
-      });
-
-      await this.journalEntryRepository.save(entry);
-      createdCount += 1;
-
-      if (!isBalanced) {
-        transaction.status = AccountingTransactionStatus.Review;
-        transaction.error = "debit and credit mismatch";
-        reviewCount += 1;
-      } else {
-        transaction.status = AccountingTransactionStatus.Processed;
-        transaction.error = null;
-        processedCount += 1;
-      }
-
-      await this.transactionRepository.save(transaction);
+      const result = await this.processTransactionWithRule(transaction, rule);
+      createdCount += result.createdCount;
+      reviewCount += result.reviewCount;
+      processedCount += result.processedCount;
     }
 
     if (missingRuleCategories.size > 0) {
@@ -149,6 +239,73 @@ export class AccountingService {
     return {
       createdCount,
       processedCount,
+      reviewCount,
+    };
+  }
+
+  async rebuildJournalEntries(payload: RebuildJournalDto) {
+    const rule = await this.ruleRepository.findOne({
+      where: { id: payload.ruleId },
+    });
+
+    if (!rule) {
+      throw new NotFoundException("accounting rule not found");
+    }
+
+    const targetStatuses =
+      payload.mode === JournalRebuildMode.Retroactive
+        ? [
+            AccountingTransactionStatus.Ready,
+            AccountingTransactionStatus.Review,
+            AccountingTransactionStatus.Processed,
+          ]
+        : [
+            AccountingTransactionStatus.Ready,
+            AccountingTransactionStatus.Review,
+          ];
+
+    const transactions = await this.transactionRepository.find({
+      where: {
+        type: rule.type,
+        category: rule.category,
+        status: In(targetStatuses),
+        ...this.buildDateRangeFilter(payload),
+      },
+      order: { date: "ASC" },
+    });
+
+    let reversedCount = 0;
+    let rebuiltCount = 0;
+    let reviewCount = 0;
+
+    for (const transaction of transactions) {
+      if (
+        transaction.status === AccountingTransactionStatus.Cancelled ||
+        transaction.status === AccountingTransactionStatus.Corrected
+      ) {
+        continue;
+      }
+
+      if (payload.mode === JournalRebuildMode.Retroactive) {
+        reversedCount += await this.createReversalEntries(transaction, {
+          ruleId: rule.id,
+          mode: payload.mode,
+        });
+      }
+
+      const result = await this.processTransactionWithRule(transaction, rule, {
+        resetStatus:
+          payload.mode === JournalRebuildMode.Retroactive &&
+          transaction.status === AccountingTransactionStatus.Processed,
+        memoSuffix: `[REBUILD] ruleId=${rule.id} / mode=${payload.mode}`,
+      });
+      rebuiltCount += result.createdCount;
+      reviewCount += result.reviewCount;
+    }
+
+    return {
+      rebuiltCount,
+      reversedCount,
       reviewCount,
     };
   }
@@ -271,6 +428,66 @@ export class AccountingService {
     const buffer = await workbook.xlsx.writeBuffer();
 
     return Buffer.isBuffer(buffer) ? buffer : Buffer.from(buffer);
+  }
+
+  async getRules(query: RuleQueryDto) {
+    const where = {
+      ...(query.type ? { type: query.type } : {}),
+      ...(query.category ? { category: query.category } : {}),
+    };
+
+    const rules = await this.ruleRepository.find({
+      where,
+      order: { type: "ASC", category: "ASC" },
+    });
+
+    return {
+      totalCount: rules.length,
+      rules,
+    };
+  }
+
+  async createRule(payload: CreateRuleDto) {
+    const entity = this.ruleRepository.create(payload);
+
+    try {
+      return await this.ruleRepository.save(entity);
+    } catch (error) {
+      this.handleRuleError(error);
+    }
+  }
+
+  async updateRule(id: number, payload: UpdateRuleDto) {
+    const existing = await this.ruleRepository.findOne({ where: { id } });
+
+    if (!existing) {
+      throw new NotFoundException("accounting rule not found");
+    }
+
+    const entity = this.ruleRepository.create({
+      ...existing,
+      ...payload,
+    });
+
+    try {
+      return await this.ruleRepository.save(entity);
+    } catch (error) {
+      this.handleRuleError(error);
+    }
+  }
+
+  async deleteRule(id: number) {
+    const existing = await this.ruleRepository.findOne({ where: { id } });
+
+    if (!existing) {
+      throw new NotFoundException("accounting rule not found");
+    }
+
+    await this.ruleRepository.remove(existing);
+
+    return {
+      deletedId: id,
+    };
   }
 
   private async exportExcelData(query: ExportExcelQueryDto) {
@@ -534,9 +751,13 @@ export class AccountingService {
     } while (cursor);
 
     const transactions: NotionTransactionDto[] = [];
+    const notionPageIds = new Set<string>();
     let skippedCount = 0;
 
     for (const page of results) {
+      if (page?.id) {
+        notionPageIds.add(page.id);
+      }
       const parsed = this.parseNotionPage(page);
 
       if (!parsed) {
@@ -547,7 +768,7 @@ export class AccountingService {
       transactions.push(parsed);
     }
 
-    return { transactions, skippedCount };
+    return { transactions, skippedCount, notionPageIds };
   }
 
   private parseNotionPage(page: any): NotionTransactionDto | null {
@@ -576,6 +797,14 @@ export class AccountingService {
     const categoryValue =
       this.getTextProperty(properties, this.notionPropertyMap.category) ??
       typeValue;
+    const correctionReason = this.getTextProperty(
+      properties,
+      this.notionPropertyMap.correctionReason,
+    );
+    const cancellationReason = this.getTextProperty(
+      properties,
+      this.notionPropertyMap.cancellationReason,
+    );
 
     if (
       !notionPageId ||
@@ -604,6 +833,10 @@ export class AccountingService {
       amountIncludesVat: vatIncluded,
       vatType: normalizedVatType,
       category: categoryValue,
+      notionLastEditedAt: page.last_edited_time ?? undefined,
+      notionArchived: Boolean(page.archived || page.in_trash),
+      correctionReason: correctionReason ?? undefined,
+      cancellationReason: cancellationReason ?? undefined,
       counterparty:
         this.getTextProperty(properties, this.notionPropertyMap.counterparty) ??
         undefined,
@@ -716,5 +949,116 @@ export class AccountingService {
     }
 
     return null;
+  }
+
+  private async processTransactionWithRule(
+    transaction: AccountingTransactionEntity,
+    rule: AccountingRuleEntity,
+    options: {
+      resetStatus?: boolean;
+      memoSuffix?: string;
+    } = {},
+  ) {
+    const journalLines = this.buildJournalLines(transaction, rule);
+    const isBalanced = this.isBalanced(journalLines);
+    const memo = this.buildEntryMemo(transaction.memo, options.memoSuffix);
+
+    const entry = this.journalEntryRepository.create({
+      transactionId: transaction.id,
+      memo,
+      isBalanced,
+      lines: journalLines,
+    });
+
+    await this.journalEntryRepository.save(entry);
+
+    if (options.resetStatus) {
+      transaction.status = AccountingTransactionStatus.Ready;
+    }
+
+    if (!isBalanced) {
+      transaction.status = AccountingTransactionStatus.Review;
+      transaction.error = "debit and credit mismatch";
+      await this.transactionRepository.save(transaction);
+      return { createdCount: 1, reviewCount: 1, processedCount: 0 };
+    }
+
+    transaction.status = AccountingTransactionStatus.Processed;
+    transaction.error = null;
+    await this.transactionRepository.save(transaction);
+    return { createdCount: 1, reviewCount: 0, processedCount: 1 };
+  }
+
+  private async createReversalEntries(
+    transaction: AccountingTransactionEntity,
+    context: { ruleId: number; mode: JournalRebuildMode },
+  ) {
+    const entries = await this.journalEntryRepository.find({
+      where: { transactionId: transaction.id },
+      relations: { lines: true },
+      order: { createdDt: "DESC" },
+    });
+
+    if (entries.length === 0) {
+      return 0;
+    }
+
+    for (const entry of entries) {
+      const memoSuffix = this.buildReversalMemo(context, entry.id);
+      const reversalLines = entry.lines.map((line) =>
+        this.journalLineRepository.create({
+          account: line.account,
+          side:
+            line.side === AccountingLineSide.Debit
+              ? AccountingLineSide.Credit
+              : AccountingLineSide.Debit,
+          amount: line.amount,
+        }),
+      );
+
+      const reversalEntry = this.journalEntryRepository.create({
+        transactionId: transaction.id,
+        memo: memoSuffix,
+        isBalanced: true,
+        lines: reversalLines,
+      });
+
+      await this.journalEntryRepository.save(reversalEntry);
+    }
+
+    return entries.length;
+  }
+
+  private buildEntryMemo(original: string | null, suffix?: string) {
+    if (!suffix) {
+      return original ?? null;
+    }
+
+    if (!original) {
+      return suffix;
+    }
+
+    return `${original} | ${suffix}`;
+  }
+
+  private buildReversalMemo(
+    context: { ruleId: number; mode: JournalRebuildMode },
+    entryId: number,
+  ) {
+    return `[REVERSAL] ruleId=${context.ruleId} / sourceEntry=${entryId} / mode=${context.mode}`;
+  }
+
+  private handleRuleError(error: unknown): never {
+    if (error instanceof QueryFailedError) {
+      const driverError = error.driverError as {
+        code?: string;
+        message?: string;
+      };
+      if (driverError?.code === "ER_DUP_ENTRY") {
+        throw new BadRequestException("rule already exists for type/category");
+      }
+    }
+
+    throw error;
   }
 }

--- a/src/accounting/dto/create-rule.dto.ts
+++ b/src/accounting/dto/create-rule.dto.ts
@@ -1,0 +1,48 @@
+import { ApiProperty } from "@nestjs/swagger";
+import { IsEnum, IsNotEmpty, IsString } from "class-validator";
+import {
+  AccountingTransactionType,
+  AccountingVatMode,
+} from "entities/accounting/accounting.enums";
+
+export class CreateRuleDto {
+  @IsString()
+  @IsNotEmpty()
+  @ApiProperty({
+    description: "카테고리",
+    example: "비품비",
+  })
+  category: string;
+
+  @IsEnum(AccountingTransactionType)
+  @ApiProperty({
+    description: "거래 유형",
+    enum: AccountingTransactionType,
+    example: AccountingTransactionType.Expense,
+  })
+  type: AccountingTransactionType;
+
+  @IsString()
+  @IsNotEmpty()
+  @ApiProperty({
+    description: "차변 계정",
+    example: "비품비",
+  })
+  debitAccount: string;
+
+  @IsString()
+  @IsNotEmpty()
+  @ApiProperty({
+    description: "대변 계정",
+    example: "카드미지급금",
+  })
+  creditAccount: string;
+
+  @IsEnum(AccountingVatMode)
+  @ApiProperty({
+    description: "부가세 분리 방식",
+    enum: AccountingVatMode,
+    example: AccountingVatMode.Split,
+  })
+  vatMode: AccountingVatMode;
+}

--- a/src/accounting/dto/notion-transaction.dto.ts
+++ b/src/accounting/dto/notion-transaction.dto.ts
@@ -84,4 +84,36 @@ export class NotionTransactionDto {
     example: "12월 구독료",
   })
   memo?: string;
+
+  @IsOptional()
+  @IsDateString()
+  @ApiPropertyOptional({
+    description: "노션 최종 수정일",
+    example: "2026-01-30T12:00:00.000Z",
+  })
+  notionLastEditedAt?: string;
+
+  @IsOptional()
+  @IsBoolean()
+  @ApiPropertyOptional({
+    description: "노션 아카이브 여부",
+    example: false,
+  })
+  notionArchived?: boolean;
+
+  @IsOptional()
+  @IsString()
+  @ApiPropertyOptional({
+    description: "정정 사유",
+    example: "금액 입력 오류",
+  })
+  correctionReason?: string;
+
+  @IsOptional()
+  @IsString()
+  @ApiPropertyOptional({
+    description: "취소 사유",
+    example: "거래 취소",
+  })
+  cancellationReason?: string;
 }

--- a/src/accounting/dto/rebuild-journal.dto.ts
+++ b/src/accounting/dto/rebuild-journal.dto.ts
@@ -1,0 +1,42 @@
+import { ApiProperty, ApiPropertyOptional } from "@nestjs/swagger";
+import { IsDateString, IsEnum, IsNumber, IsOptional } from "class-validator";
+import { Type } from "class-transformer";
+
+export enum JournalRebuildMode {
+  NonRetroactive = "NON_RETROACTIVE",
+  Retroactive = "RETROACTIVE",
+}
+
+export class RebuildJournalDto {
+  @Type(() => Number)
+  @IsNumber()
+  @ApiProperty({
+    description: "규칙 아이디",
+    example: 1,
+  })
+  ruleId: number;
+
+  @IsEnum(JournalRebuildMode)
+  @ApiProperty({
+    description: "재분개 방식",
+    enum: JournalRebuildMode,
+    example: JournalRebuildMode.NonRetroactive,
+  })
+  mode: JournalRebuildMode;
+
+  @IsOptional()
+  @IsDateString()
+  @ApiPropertyOptional({
+    description: "재분개 시작일",
+    example: "2026-01-01",
+  })
+  startDate?: string;
+
+  @IsOptional()
+  @IsDateString()
+  @ApiPropertyOptional({
+    description: "재분개 종료일",
+    example: "2026-01-31",
+  })
+  endDate?: string;
+}

--- a/src/accounting/dto/rule-query.dto.ts
+++ b/src/accounting/dto/rule-query.dto.ts
@@ -1,0 +1,22 @@
+import { ApiPropertyOptional } from "@nestjs/swagger";
+import { IsEnum, IsOptional, IsString } from "class-validator";
+import { AccountingTransactionType } from "entities/accounting/accounting.enums";
+
+export class RuleQueryDto {
+  @IsOptional()
+  @IsEnum(AccountingTransactionType)
+  @ApiPropertyOptional({
+    description: "거래 유형",
+    enum: AccountingTransactionType,
+    example: AccountingTransactionType.Sale,
+  })
+  type?: AccountingTransactionType;
+
+  @IsOptional()
+  @IsString()
+  @ApiPropertyOptional({
+    description: "카테고리",
+    example: "비품비",
+  })
+  category?: string;
+}

--- a/src/accounting/dto/update-rule.dto.ts
+++ b/src/accounting/dto/update-rule.dto.ts
@@ -1,0 +1,50 @@
+import { ApiPropertyOptional } from "@nestjs/swagger";
+import { IsEnum, IsOptional, IsString } from "class-validator";
+import {
+  AccountingTransactionType,
+  AccountingVatMode,
+} from "entities/accounting/accounting.enums";
+
+export class UpdateRuleDto {
+  @IsOptional()
+  @IsString()
+  @ApiPropertyOptional({
+    description: "카테고리",
+    example: "비품비",
+  })
+  category?: string;
+
+  @IsOptional()
+  @IsEnum(AccountingTransactionType)
+  @ApiPropertyOptional({
+    description: "거래 유형",
+    enum: AccountingTransactionType,
+    example: AccountingTransactionType.Expense,
+  })
+  type?: AccountingTransactionType;
+
+  @IsOptional()
+  @IsString()
+  @ApiPropertyOptional({
+    description: "차변 계정",
+    example: "비품비",
+  })
+  debitAccount?: string;
+
+  @IsOptional()
+  @IsString()
+  @ApiPropertyOptional({
+    description: "대변 계정",
+    example: "카드미지급금",
+  })
+  creditAccount?: string;
+
+  @IsOptional()
+  @IsEnum(AccountingVatMode)
+  @ApiPropertyOptional({
+    description: "부가세 분리 방식",
+    enum: AccountingVatMode,
+    example: AccountingVatMode.Split,
+  })
+  vatMode?: AccountingVatMode;
+}


### PR DESCRIPTION
## Summary
- Add accounting rule management APIs (list/create/update/delete) and corresponding DTOs to maintain rule definitions directly.
- Introduce rule-based journal rebuild API with `NON_RETROACTIVE` and `RETROACTIVE` modes, including reversal entry generation for retroactive rebuilds.
- Extend Notion sync and transaction model for revision/correction/cancellation tracking, and add migration for new columns and unique/index constraints.
- Update README accounting endpoint docs for the new rebuild and rule APIs.

## Ref
- 해당 브랜치 Merge 진행 완료 후 반드시 운영서버에 배포시 마이그레이션 실행 필요(DB 보완으로 인한 필수)